### PR TITLE
Add tests for corner cases

### DIFF
--- a/src/test/examples/basic.jl
+++ b/src/test/examples/basic.jl
@@ -1,4 +1,4 @@
-function __test_basic_bool_min(
+function _test_basic_bool_min(
     config!::Function,
     sampler::Type{S},
     n::Integer,
@@ -47,7 +47,7 @@ function __test_basic_bool_min(
     return nothing
 end
 
-function __test_basic_bool_max(
+function _test_basic_bool_max(
     config!::Function,
     sampler::Type{S},
     n::Integer,
@@ -96,7 +96,7 @@ function __test_basic_bool_max(
     return nothing
 end
 
-function __test_basic_spin_min(
+function _test_basic_spin_min(
     config!::Function,
     sampler::Type{S},
     n::Integer,
@@ -147,7 +147,7 @@ function __test_basic_spin_min(
     return nothing
 end
 
-function __test_basic_spin_max(
+function _test_basic_spin_max(
     config!::Function,
     sampler::Type{S},
     n::Integer,
@@ -198,7 +198,7 @@ function __test_basic_spin_max(
     return nothing
 end
 
-function __test_basic_examples(
+function _test_basic_examples(
     config!::Function,
     sampler::Type{S},
 ) where {T,S<:AbstractSampler{T}}
@@ -213,10 +213,10 @@ function __test_basic_examples(
         J = T[0 4 4; 0 0 4; 0 0 0]
         h = T[-1; -1; -1]
 
-        __test_basic_bool_min(config!, sampler, n, Q)
-        __test_basic_bool_max(config!, sampler, n, Q)
-        __test_basic_spin_min(config!, sampler, n, h, J)
-        __test_basic_spin_max(config!, sampler, n, h, J)
+        _test_basic_bool_min(config!, sampler, n, Q)
+        _test_basic_bool_max(config!, sampler, n, Q)
+        _test_basic_spin_min(config!, sampler, n, h, J)
+        _test_basic_spin_max(config!, sampler, n, h, J)
     end
 
     return nothing

--- a/src/test/examples/corner.jl
+++ b/src/test/examples/corner.jl
@@ -1,0 +1,54 @@
+raw"""
+    _test_corner_blanks(config!::Function, sampler::Type{S}) where {S<:AbstractSampler}
+
+This test case probes problems with blanks in the objective function.
+Some solvers will only return answers for variables present in the expression[^QUBODrivers#6].
+
+```math
+\begin{array}{rl}
+\min          & x_1 + x_3         \\
+\textrm{s.t.} & x_1 in \mathbb{B} \\
+              & x_2 in \mathbb{B} \\
+              & x_3 in \mathbb{B}
+\end{array}
+```
+
+## Related Issues
+[^QUBODrivers#6]: QUBODrivers.jl Issue [#6](https://github.com/psrenergy/QUBODrivers.jl/issues/6)
+
+"""
+function _test_corner_blanks(
+    config!::Function,
+    sampler::Type{S},
+) where {T,S<:AbstractSampler{T}}
+    @testset "Blanks" begin
+        # Build Model
+        model = MOI.instantiate(sampler; with_bridge_type = T)
+
+        x, _ = MOI.add_constrained_variables(model, fill(MOI.ZeroOne(), 3))
+
+        MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+        MOI.set(
+            model,
+            MOI.ObjectiveFunction{SAF{T}}(),
+            SAF{T}(SAT{T}[SAT{T}(one(T), x[1]), SAT{T}(one(T), x[3])], zero(T)),
+        )
+
+        config!(model)
+
+        MOI.optimize!(model)
+
+        Test.@test MOI.get(model, MOI.ResultCount()) > 0
+    end
+end
+
+function _test_corner_examples(
+    config!::Function,
+    sampler::Type{S},
+) where {S<:AbstractSampler}
+    Test.@testset "⊚ Corner cases ⊚" begin
+        _test_corner_blanks(config!, sampler)
+    end
+
+    return nothing
+end

--- a/src/test/examples/examples.jl
+++ b/src/test/examples/examples.jl
@@ -1,0 +1,14 @@
+include("basic.jl")
+include("corner.jl")
+
+function _test_examples(
+    config!::Function,
+    sampler::Type{S},
+) where {S<:AbstractSampler}
+    Test.@testset "→ Examples" begin
+        _test_basic_examples(config!, sampler)
+        _test_corner_examples(config!, sampler)
+    end
+    
+    return nothing
+end

--- a/src/test/interface/automatic.jl
+++ b/src/test/interface/automatic.jl
@@ -1,4 +1,4 @@
-function __test_automatic_interface(::Function, ::Type{S}) where {S<:AutomaticSampler}
+function _test_automatic_interface(::Function, ::Type{S}) where {S<:AutomaticSampler}
     Test.@testset "QUBODrivers (Automatic)" verbose = true begin
         Test.@test hasmethod(QUBODrivers.sample, (S,))
     end

--- a/src/test/interface/moi.jl
+++ b/src/test/interface/moi.jl
@@ -1,4 +1,4 @@
-function __test_moi_interface(::Function, ::Type{S}) where {S<:AbstractSampler}
+function _test_moi_interface(::Function, ::Type{S}) where {S<:AbstractSampler}
     Test.@testset "MOI" verbose = true begin
         Test.@testset "`optimize!` Interface" begin
             # Emptiness

--- a/src/test/test.jl
+++ b/src/test/test.jl
@@ -3,12 +3,13 @@ include("interface/moi.jl")
 include("interface/automatic.jl")
 
 # Example Tests
-include("examples/basic.jl")
+include("examples/examples.jl")
 
 @doc raw"""
     test(optimizer::Type{S}; examples::Bool=false) where {S<:AbstractSampler}
     test(config!::Function, optimizer::Type{S}; examples::Bool=false) where {S<:AbstractSampler}
-""" function test end
+"""
+function test end
 
 function QUBODrivers.test(::Type{S}; examples::Bool=true) where {S<:AbstractSampler}
     QUBODrivers.test(identity, S; examples)
@@ -22,19 +23,17 @@ function QUBODrivers.test(config!::Function, ::Type{S}; examples::Bool=true) whe
     return nothing
 end
 
-function QUBODrivers.test(config!::Function, S::Type{<:AbstractSampler{T}}; examples::Bool=true) where {T}
+function QUBODrivers.test(config!::Function, ::Type{S}; examples::Bool=true) where {T,S<:AbstractSampler{T}}
     solver_name = MOI.get(S(), MOI.SolverName())
 
     Test.@testset "☢ QUBODrivers' Tests for $(solver_name) ☢" verbose = true begin
         Test.@testset "→ Interface" begin
-            __test_moi_interface(config!, S)
-            __test_automatic_interface(config!, S)
+            _test_moi_interface(config!, S)
+            _test_automatic_interface(config!, S)
         end
 
         if examples
-            Test.@testset "→ Examples" begin
-                __test_basic_examples(config!, S)
-            end
+            _test_examples(config!, S)
         end
     end
 


### PR DESCRIPTION
This PR aims to add a test suite for keeping specific yet not commonly noticed issues under the radar.

As a starting point, it adds tests for tracking #6.

Merging it closes #6 