### PR TITLE
Add `MOI_PythonCall` extension + Add

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBODrivers"
 uuid = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 authors = ["pedromxavier <pedroxavier@psr-inc.com>", "pedroripper <pedroripper@psr-inc.com>", "AndradeTiago <tiago.andrade@psr-inc.com>", "joaquimg <joaquim@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
@@ -10,7 +10,14 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[weakdeps]
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
+
+[extensions]
+MOI_PythonCall = ["PythonCall"]
+
 [compat]
 MathOptInterface = "1"
+PythonCall = "0.9.14"
 QUBOTools = "~0.9"
 julia = "1.9"

--- a/ext/MOI_PythonCall.jl
+++ b/ext/MOI_PythonCall.jl
@@ -1,0 +1,10 @@
+module MOI_PythonCall
+
+import MathOptInterface as MOI
+import PythonCall
+
+if !hasmethod(MOI.Utilities.map_indices, Tuple{PythonCall.Py})
+    MOI.Utilities.map_indices(::Function, obj::PythonCall.Py) = obj
+end
+
+end # module MOI_PythonCall

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,6 @@
 [deps]
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+PythonCall = "0.9.14"

--- a/test/ext/MOI_PythonCall.jl
+++ b/test/ext/MOI_PythonCall.jl
@@ -1,0 +1,21 @@
+function test_moi_pythoncall_ext()
+    @testset "⚠ MathOptInterface-PythonCall ⚠" begin
+        py_objs = [
+            PythonCall.pylist([1, 2, 3]),
+            PythonCall.pydict(Dict("a" => 1, "b" => 2, "c" => 3)),
+            PythonCall.pytuple((1, 2, 3)),
+            PythonCall.pyset(Set([1, 2, 3])),
+            PythonCall.pyint(1),
+            PythonCall.pyfloat(1.0),
+            PythonCall.pycomplex(1.0 + 1.0im),
+            PythonCall.pystr("1"),
+            PythonCall.pybool(true),
+        ]
+
+        for py_obj in py_objs
+            @test MOI.Utilities.map_indices(identity, py_obj) === py_obj
+        end
+    end
+
+    return nothing
+end

--- a/test/ext/ext.jl
+++ b/test/ext/ext.jl
@@ -1,0 +1,9 @@
+include("MOI_PythonCall.jl")
+
+function test_extensions()
+    @testset "□ Extensions" verbose = true begin
+        test_moi_pythoncall_ext()
+    end
+
+    return nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,18 +1,23 @@
 using Test
+using PythonCall
 using QUBODrivers
-using QUBODrivers: QUBOTools
+using QUBODrivers: MOI, QUBOTools
 
-const VI = MOI.VariableIndex
+const MOIU = MOI.Utilities
+const VI   = MOI.VariableIndex
 
 include("assets/test_macro_throws.jl")
 
 include("setup/setup.jl")
 include("drivers/sampler_bundle.jl")
 
+include("ext/ext.jl")
+
 function main()
     @testset "◈ ◈ ◈ QUBODrivers.jl Test Suite ◈ ◈ ◈" verbose = true begin
         test_setup_macro()
         test_sampler_bundle()
+        test_extensions()
     end
 
     return nothing


### PR DESCRIPTION
This PR aims to provide a `MOI-PythonCall` extension, as discussed in jump-dev/MathOptInterface.jl#2301. Merging it closes #9.

It contains the extension itself and tests.