### PR TITLE
Remove duplicate `supports` method from @setup macro

### DIFF
--- a/src/library/setup/quote.jl
+++ b/src/library/setup/quote.jl
@@ -222,9 +222,6 @@ function __setup_quote_moi_attrs(spec::_SamplerSpec)
             return nothing
         end
 
-        # MOI.NumberOfThreads - Support
-        MOI.supports(::$(Optimizer), ::Union{MOI.NumberOfThreads, raw_attr"moi/numberofthreads"}) = true
-
         # MOI.VariablePrimalStart - get
         function MOI.get(sampler::$(Optimizer), ::MOI.VariablePrimalStart, vi::VI)
             i = QUBOTools.index(sampler, vi)


### PR DESCRIPTION
Hello there! I was checking the methods on [Tensolver.jl](https://github.com/SECQUOIA/TenSolver.jl) using [Aqua.jl](https://github.com/JuliaTesting/Aqua.jl) and it failed for method ambiguities.
Apparently `MOI.supports` is defined twice in `QUBODrivers.@setup` for the same parameters.
This PR removes the extra code.