### PR TITLE
Update repository references to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,7 +2,7 @@
 name: Documentation
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: '*'
   pull_request:
     types: [opened, synchronize, reopened]

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
         <img src="https://img.shields.io/badge/arXiv-2307.02577-b31b1b.svg" alt="arXiv"/>
     </a>
     <a href="https://codecov.io/gh/JuliaQUBO/QUBODrivers.jl">
-        <img src="https://codecov.io/gh/JuliaQUBO/QUBODrivers.jl/branch/master/graph/badge.svg?token=729WFU0752"/>
+        <img src="https://codecov.io/gh/JuliaQUBO/QUBODrivers.jl/branch/main/graph/badge.svg?token=729WFU0752"/>
     </a>
     <a href="https://github.com/JuliaQUBO/QUBODrivers.jl/actions/workflows/ci.yml">
-        <img src="https://github.com/JuliaQUBO/QUBODrivers.jl/actions/workflows/ci.yml/badge.svg?branch=master" alt="CI" />
+        <img src="https://github.com/JuliaQUBO/QUBODrivers.jl/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" />
     </a>
     <a href="https://www.youtube.com/watch?v=OTmzlTbqdNo">
         <img src="https://img.shields.io/badge/JuliaCon-2022-9558b2" alt="JuliaCon 2022">


### PR DESCRIPTION
## Summary
- update CI and documentation workflow push filters from `master` to `main`
- update the README Codecov and CI badges to use `main`
- leave unrelated external `master` references alone, since they point to `JuliaQUBO/QUBO.jl`

## Why
The repository default branch was renamed from `master` to `main`, so the in-repo branch references need to follow it. Without this follow-up, pushes to `main` would not match the existing workflow branch filters.

## Verification
- confirmed the repository default branch is now `main`
- ran `git diff --check`
- verified only this repository's `master` references were changed
