### PR TITLE
Add shared label automation workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 documentation:
   - changed-files:
-      - all-globs-to-all-files:
+      - any-glob-to-all-files:
           - "docs/**"
           - "**/*.md"
           - "**/*.rst"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,14 @@
+documentation:
+  - changed-files:
+      - all-globs-to-all-files:
+          - "docs/**"
+          - "**/*.md"
+          - "**/*.rst"
+          - "README*"
+          - "CHANGELOG*"
+          - "NEWS*"
+          - "CITATION.cff"
+          - "LICENSE*"
+          - "papers/**"
+          - ".github/ISSUE_TEMPLATE/**"
+          - ".github/pull_request_template.md"

--- a/.github/tests/test_label_automation.py
+++ b/.github/tests/test_label_automation.py
@@ -1,9 +1,15 @@
 import pathlib
 import unittest
 
+import yaml
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
-DOC_PATTERNS = (
+
+# Minimum set of glob patterns the documentation label must cover.
+# This is a contract floor — removing a pattern here is a deliberate
+# decision to relax the labeler; adding one to labeler.yml without
+# adding it here is allowed.
+REQUIRED_DOC_PATTERNS = (
     "docs/**",
     "**/*.md",
     "**/*.rst",
@@ -22,14 +28,38 @@ class LabelAutomationContractTests(unittest.TestCase):
     def read_text(self, relative_path: str) -> str:
         return (ROOT / relative_path).read_text(encoding="utf-8")
 
+    def load_yaml(self, relative_path: str):
+        return yaml.safe_load(self.read_text(relative_path))
+
     def test_documentation_labeler_uses_any_glob_to_all_files(self) -> None:
-        contents = self.read_text(".github/labeler.yml")
+        labeler = self.load_yaml(".github/labeler.yml")
 
-        self.assertIn("any-glob-to-all-files:", contents)
-        self.assertNotIn("all-globs-to-all-files:", contents)
+        self.assertIn("documentation", labeler)
 
-        for pattern in DOC_PATTERNS:
-            self.assertIn(f'          - "{pattern}"', contents)
+        all_glob_patterns: list = []
+        for rule in labeler["documentation"]:
+            for entry in rule.get("changed-files", []):
+                self.assertNotIn(
+                    "all-globs-to-all-files",
+                    entry,
+                    "documentation label uses all-globs-to-all-files — this requires every "
+                    "pattern to match every changed file, so a PR touching only docs/ would "
+                    "never receive the label. Use any-glob-to-all-files instead.",
+                )
+                all_glob_patterns.extend(entry.get("any-glob-to-all-files", []))
+
+        self.assertTrue(
+            all_glob_patterns,
+            "documentation label has no any-glob-to-all-files entries",
+        )
+
+        for pattern in REQUIRED_DOC_PATTERNS:
+            self.assertIn(
+                pattern,
+                all_glob_patterns,
+                f"Required pattern {pattern!r} is missing from the documentation label's "
+                "any-glob-to-all-files list",
+            )
 
     def test_sync_permissions_use_issues_only(self) -> None:
         header = self.read_text(".github/workflows/label-sync.yml").split("jobs:", 1)[0]

--- a/.github/tests/test_label_automation.py
+++ b/.github/tests/test_label_automation.py
@@ -1,0 +1,58 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+DOC_PATTERNS = (
+    "docs/**",
+    "**/*.md",
+    "**/*.rst",
+    "README*",
+    "CHANGELOG*",
+    "NEWS*",
+    "CITATION.cff",
+    "LICENSE*",
+    "papers/**",
+    ".github/ISSUE_TEMPLATE/**",
+    ".github/pull_request_template.md",
+)
+
+
+class LabelAutomationContractTests(unittest.TestCase):
+    def read_text(self, relative_path: str) -> str:
+        return (ROOT / relative_path).read_text(encoding="utf-8")
+
+    def test_documentation_labeler_uses_any_glob_to_all_files(self) -> None:
+        contents = self.read_text(".github/labeler.yml")
+
+        self.assertIn("any-glob-to-all-files:", contents)
+        self.assertNotIn("all-globs-to-all-files:", contents)
+
+        for pattern in DOC_PATTERNS:
+            self.assertIn(f'          - "{pattern}"', contents)
+
+    def test_sync_permissions_use_issues_only(self) -> None:
+        header = self.read_text(".github/workflows/label-sync.yml").split("jobs:", 1)[0]
+
+        self.assertIn("permissions:\n  contents: read\n  issues: write\n", header)
+        self.assertNotIn("pull-requests:", header)
+
+    def test_backfill_permissions_use_pull_request_read(self) -> None:
+        header = self.read_text(".github/workflows/label-backfill.yml").split("jobs:", 1)[0]
+
+        self.assertIn(
+            "permissions:\n  contents: read\n  issues: write\n  pull-requests: read\n",
+            header,
+        )
+
+    def test_pr_labeler_keeps_pull_request_write(self) -> None:
+        header = self.read_text(".github/workflows/pr-labeler.yml").split("jobs:", 1)[0]
+
+        self.assertIn(
+            "permissions:\n  contents: read\n  pull-requests: write\n",
+            header,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/label-backfill.yml
+++ b/.github/workflows/label-backfill.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   backfill:
-    uses: JuliaQUBO/.github/.github/workflows/backfill-labels.yml@e3c5c6d53b5be000ba40fe80946ec11181a6e5cf
+    uses: JuliaQUBO/.github/.github/workflows/backfill-labels.yml@7373363a26cd68189b1f35f1d3fd31d46787a760
     with:
       dry_run: ${{ inputs.dry_run }}
       max_items: ${{ inputs.max_items }}

--- a/.github/workflows/label-backfill.yml
+++ b/.github/workflows/label-backfill.yml
@@ -1,0 +1,27 @@
+name: Backfill Shared Labels
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Preview label changes without applying them.
+        required: false
+        default: true
+        type: boolean
+      max_items:
+        description: Maximum number of open issues and PRs to scan.
+        required: false
+        default: 100
+        type: number
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  backfill:
+    uses: JuliaQUBO/.github/.github/workflows/backfill-labels.yml@e3c5c6d53b5be000ba40fe80946ec11181a6e5cf
+    with:
+      dry_run: ${{ inputs.dry_run }}
+      max_items: ${{ inputs.max_items }}

--- a/.github/workflows/label-backfill.yml
+++ b/.github/workflows/label-backfill.yml
@@ -17,7 +17,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   backfill:

--- a/.github/workflows/label-backfill.yml
+++ b/.github/workflows/label-backfill.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   backfill:
-    uses: JuliaQUBO/.github/.github/workflows/backfill-labels.yml@7373363a26cd68189b1f35f1d3fd31d46787a760
+    uses: JuliaQUBO/.github/.github/workflows/backfill-labels.yml@02781d5b27dd8f0d2bc5b1fe3845eff7113244ec
     with:
       dry_run: ${{ inputs.dry_run }}
       max_items: ${{ inputs.max_items }}

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,23 @@
+name: Sync Shared Labels
+
+on:
+  schedule:
+    - cron: "47 4 1 * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Preview label changes without applying them.
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  sync:
+    uses: JuliaQUBO/.github/.github/workflows/sync-labels.yml@e3c5c6d53b5be000ba40fe80946ec11181a6e5cf
+    with:
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -14,7 +14,6 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
 
 jobs:
   sync:

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -18,6 +18,6 @@ permissions:
 
 jobs:
   sync:
-    uses: JuliaQUBO/.github/.github/workflows/sync-labels.yml@7373363a26cd68189b1f35f1d3fd31d46787a760
+    uses: JuliaQUBO/.github/.github/workflows/sync-labels.yml@02781d5b27dd8f0d2bc5b1fe3845eff7113244ec
     with:
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -18,6 +18,6 @@ permissions:
 
 jobs:
   sync:
-    uses: JuliaQUBO/.github/.github/workflows/sync-labels.yml@e3c5c6d53b5be000ba40fe80946ec11181a6e5cf
+    uses: JuliaQUBO/.github/.github/workflows/sync-labels.yml@7373363a26cd68189b1f35f1d3fd31d46787a760
     with:
       dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,19 @@
+name: Label Pull Requests
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    uses: JuliaQUBO/.github/.github/workflows/pr-labeler.yml@e3c5c6d53b5be000ba40fe80946ec11181a6e5cf
+    with:
+      configuration_path: .github/labeler.yml

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   label:
-    uses: JuliaQUBO/.github/.github/workflows/pr-labeler.yml@7373363a26cd68189b1f35f1d3fd31d46787a760
+    uses: JuliaQUBO/.github/.github/workflows/pr-labeler.yml@02781d5b27dd8f0d2bc5b1fe3845eff7113244ec
     with:
       configuration_path: .github/labeler.yml

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -14,6 +14,6 @@ permissions:
 
 jobs:
   label:
-    uses: JuliaQUBO/.github/.github/workflows/pr-labeler.yml@e3c5c6d53b5be000ba40fe80946ec11181a6e5cf
+    uses: JuliaQUBO/.github/.github/workflows/pr-labeler.yml@7373363a26cd68189b1f35f1d3fd31d46787a760
     with:
       configuration_path: .github/labeler.yml

--- a/.github/workflows/validate-label-automation.yml
+++ b/.github/workflows/validate-label-automation.yml
@@ -19,12 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.x"
+
+      - name: Install test dependencies
+        run: pip install pyyaml
 
       - name: Run label automation contract tests
         run: python -m unittest discover -s .github/tests -p "test_*.py"

--- a/.github/workflows/validate-label-automation.yml
+++ b/.github/workflows/validate-label-automation.yml
@@ -1,0 +1,30 @@
+name: Validate Label Automation
+
+on:
+  pull_request:
+    paths:
+      - ".github/labeler.yml"
+      - ".github/workflows/label-sync.yml"
+      - ".github/workflows/label-backfill.yml"
+      - ".github/workflows/pr-labeler.yml"
+      - ".github/workflows/validate-label-automation.yml"
+      - ".github/tests/test_label_automation.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Run label automation contract tests
+        run: python -m unittest discover -s .github/tests -p "test_*.py"


### PR DESCRIPTION
## Summary
- add shared label sync, backfill, and PR labeler caller workflows
- add local docs-only labeler configuration
- pin reusable workflow references to JuliaQUBO/.github@e3c5c6d53b5be000ba40fe80946ec11181a6e5cf

## Notes
- this repo intentionally consumes the shared workflow commit directly so the rollout can proceed before JuliaQUBO/.github merges
