### PR TITLE
Add sampler benchmark helper

### DIFF
--- a/docs/src/manual/6-benchmarks.md
+++ b/docs/src/manual/6-benchmarks.md
@@ -3,7 +3,34 @@
 Benchmarking QUBO samplers is partly about runtime and partly about solution
 quality. QUBODrivers exposes both through standard JuMP/MOI result queries, so a
 simple benchmark can collect elapsed time, number of returned states, objective
-values, and the best state found.
+values, objective-value frequencies, and the best state found.
+
+## Benchmark a JuMP Model
+
+Build the problem once, then pass its MOI backend to `QUBODrivers.benchmark`.
+The benchmark helper copies that model into each sampler, applies any sampler
+configuration, runs `MOI.optimize!`, and returns timing and sample-quality
+metadata.
+
+```@example benchmarking-jump
+using JuMP
+using QUBODrivers
+
+model = Model()
+@variable(model, x[1:4], Bin)
+@objective(model, Min, -x[1] - 2x[2] - x[3] + 2x[1] * x[2] + x[3] * x[4])
+
+result = QUBODrivers.benchmark(RandomSampler.Optimizer, backend(model)) do sampler
+    MOI.set(sampler, MOI.RawOptimizerAttribute("num_reads"), 100)
+    MOI.set(sampler, MOI.RawOptimizerAttribute("seed"), 1)
+end
+
+(result.variables, result.result_count, result.objective_summary.minimum)
+```
+
+For large models, use stochastic samplers such as `RandomSampler` as the cheap
+baseline. `ExactSampler` is useful for small reference instances and smoke
+tests, but its exhaustive enumeration grows exponentially.
 
 ## Comparing Samplers
 
@@ -12,8 +39,10 @@ complete reference on small instances, while `RandomSampler` provides a cheap
 stochastic baseline.
 
 ```@example benchmarking
-using JuMP
 using QUBODrivers
+
+source = MOI.Utilities.Model{Float64}()
+x, _ = MOI.add_constrained_variables(source, fill(MOI.ZeroOne(), 3))
 
 Q = [
     -1.0  2.0  2.0
@@ -21,41 +50,42 @@ Q = [
      2.0  2.0 -1.0
 ]
 
-function benchmark_sampler(OptimizerType; attributes = Pair{String,Any}[])
-    model = Model(OptimizerType)
-
-    for (name, value) in attributes
-        set_optimizer_attribute(model, name, value)
-    end
-
-    @variable(model, x[1:3], Bin)
-    @objective(model, Min, x' * Q * x)
-
-    solve = @timed optimize!(model)
-
-    results = [
-        (value.(x; result=i), objective_value(model; result=i))
-        for i in 1:result_count(model)
-    ]
-
-    return (;
-        time = solve.time,
-        best = minimum(last, results),
-        n_results = length(results),
-    )
-end
-```
-
-```@example benchmarking
-exact = benchmark_sampler(ExactSampler.Optimizer)
-
-random = benchmark_sampler(
-    RandomSampler.Optimizer;
-    attributes = ["num_reads" => 100, "seed" => 1],
+MOI.set(source, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+MOI.set(
+    source,
+    MOI.ObjectiveFunction{MOI.ScalarQuadraticFunction{Float64}}(),
+    MOI.ScalarQuadraticFunction{Float64}(
+        MOI.ScalarQuadraticTerm{Float64}[
+            MOI.ScalarQuadraticTerm{Float64}(Q[i, j], x[i], x[j])
+            for i = 1:3 for j = 1:3 if i != j
+        ],
+        MOI.ScalarAffineTerm{Float64}[
+            MOI.ScalarAffineTerm{Float64}(Q[i, i], x[i])
+            for i = 1:3
+        ],
+        0.0,
+    ),
 )
 
-(exact.best, random.best)
+exact = QUBODrivers.benchmark(ExactSampler.Optimizer, source)
+
+random = QUBODrivers.benchmark(RandomSampler.Optimizer, source) do sampler
+    MOI.set(sampler, MOI.RawOptimizerAttribute("num_reads"), 100)
+    MOI.set(sampler, MOI.RawOptimizerAttribute("seed"), 1)
+end
+
+(exact.best_objective, random.best_objective)
 ```
+
+`QUBODrivers.benchmark` copies a user-provided MOI model into the sampler and
+returns a named tuple with solver metadata, objective values, result count, best
+state, best objective value, objective summary, MOI solve time, wall-clock time
+around `MOI.optimize!`, and status fields. `result.objective_summary` contains
+`minimum`, `maximum`, `mean`, and a `histogram` mapping each observed objective
+value to its frequency. The optional `do` block receives the raw sampler
+optimizer after model copy and before optimization. If no model is provided,
+`QUBODrivers.benchmark` falls back to a small built-in QUBO instance as a smoke
+benchmark.
 
 ## Timing Information
 
@@ -81,6 +111,8 @@ to be reproducible:
 
 ## Tips
 
+- Use `QUBODrivers.benchmark` as a quick interface smoke benchmark for a new
+  sampler wrapper.
 - Use `ExactSampler` on small instances to obtain a known optimum.
 - Run multiple independent trials for stochastic samplers and report summary
   statistics.
@@ -89,3 +121,7 @@ to be reproducible:
 - Use [`BenchmarkTools.jl`](https://github.com/JuliaCI/BenchmarkTools.jl) for
   micro-benchmarks with `@benchmark` or `@btime`.
 - Scale problem sizes gradually to understand how sampler performance degrades.
+
+```@docs
+QUBODrivers.benchmark
+```

--- a/docs/src/manual/6-benchmarks.md
+++ b/docs/src/manual/6-benchmarks.md
@@ -3,7 +3,7 @@
 Benchmarking QUBO samplers is partly about runtime and partly about solution
 quality. QUBODrivers exposes both through standard JuMP/MOI result queries, so a
 simple benchmark can collect elapsed time, number of returned states, objective
-values, objective-value frequencies, and the best state found.
+values, read counts, objective-value frequencies, and the best state found.
 
 ## Benchmark a JuMP Model
 
@@ -79,10 +79,11 @@ end
 
 `QUBODrivers.benchmark` copies a user-provided MOI model into the sampler and
 returns a named tuple with solver metadata, objective values, result count, best
-state, best objective value, objective summary, MOI solve time, wall-clock time
-around `MOI.optimize!`, and status fields. `result.objective_summary` contains
-`minimum`, `maximum`, `mean`, and a `histogram` mapping each observed objective
-value to its frequency. The optional `do` block receives the raw sampler
+state, best objective value, read counts, objective summary, MOI solve time,
+wall-clock time around `MOI.optimize!`, and status fields.
+`result.objective_summary` contains `minimum`, `maximum`, a read-weighted
+`mean`, `total_reads`, and a `histogram` mapping each observed objective value
+to its total read count. The optional `do` block receives the raw sampler
 optimizer after model copy and before optimization. If no model is provided,
 `QUBODrivers.benchmark` falls back to a small built-in QUBO instance as a smoke
 benchmark.

--- a/docs/src/manual/8-api.md
+++ b/docs/src/manual/8-api.md
@@ -38,10 +38,11 @@ QUBODrivers.RandomSampler.Optimizer
 QUBODrivers.IdentitySampler.Optimizer
 ```
 
-## Test Extension
+## Test and Benchmark Helpers
 
 ```@docs; canonical=false
 QUBODrivers.test
+QUBODrivers.benchmark
 ```
 
 ## Re-Exported Types

--- a/src/QUBODrivers.jl
+++ b/src/QUBODrivers.jl
@@ -10,7 +10,8 @@ Common MathOptInterface-compatible tools for QUBO and Ising samplers.
 - built-in utility samplers in `ExactSampler`, `RandomSampler`, and
   `IdentitySampler`;
 - result and model plumbing through MathOptInterface and QUBOTools;
-- an optional [`test`](@ref) suite for sampler implementations.
+- optional [`test`](@ref) and [`benchmark`](@ref) helpers for sampler
+  implementations.
 """
 module QUBODrivers
 
@@ -36,6 +37,7 @@ export MOI, Sample, SampleSet, Spin, ↓, ↑
 include("interface/sampler.jl")
 include("interface/attributes.jl")
 include("interface/test.jl")
+include("interface/benchmark.jl")
 
 include("library/sampler/wrappers/moi.jl")
 include("library/sampler/wrappers/qubotools.jl")

--- a/src/interface/benchmark.jl
+++ b/src/interface/benchmark.jl
@@ -1,0 +1,152 @@
+@doc raw"""
+    benchmark(optimizer::Type{S}; objective_sense=MOI.MIN_SENSE) where {S<:AbstractSampler}
+    benchmark(config!::Function, optimizer::Type{S}; objective_sense=MOI.MIN_SENSE) where {S<:AbstractSampler}
+    benchmark(optimizer::Type{S}, source::MOI.ModelLike) where {S<:AbstractSampler}
+    benchmark(config!::Function, optimizer::Type{S}, source::MOI.ModelLike) where {S<:AbstractSampler}
+
+Run a QUBO benchmark problem with a sampler implementation.
+
+When `source` is provided, benchmark the sampler on that MOI model. The
+no-`source` methods use a small built-in QUBO instance as a smoke benchmark.
+
+The optional `config!` function receives the raw sampler optimizer after the
+source model is copied and before optimization. This is useful for setting
+sampler attributes such as seeds, number of reads, time limits, or warm-starts.
+
+The return value is a named tuple with solver metadata, benchmark problem size,
+result count, objective values, objective-value summary statistics, the best
+result, MOI solve time, measured wall time around `MOI.optimize!`, and solver
+status fields.
+"""
+function benchmark end
+
+function benchmark(::Type{S}; kwargs...) where {S<:AbstractSampler}
+    return benchmark(identity, S; kwargs...)
+end
+
+function benchmark(config!::Function, ::Type{S}; kwargs...) where {S<:AbstractSampler}
+    return benchmark(config!, S{Float64}; kwargs...)
+end
+
+function benchmark(::Type{S}, source::MOI.ModelLike) where {S<:AbstractSampler}
+    return benchmark(identity, S, source)
+end
+
+function benchmark(config!::Function, ::Type{S}, source::MOI.ModelLike) where {S<:AbstractSampler}
+    return benchmark(config!, S{Float64}, source)
+end
+
+function benchmark(
+    config!::Function,
+    ::Type{S};
+    objective_sense = MOI.MIN_SENSE,
+) where {T,S<:AbstractSampler{T}}
+    _validate_benchmark_sense(objective_sense)
+
+    return benchmark(config!, S, _default_benchmark_model(T, objective_sense))
+end
+
+function benchmark(
+    config!::Function,
+    ::Type{S},
+    source::MOI.ModelLike,
+) where {T,S<:AbstractSampler{T}}
+    sampler = S()
+
+    MOI.copy_to(sampler, source)
+
+    variables = MOI.get(sampler, MOI.ListOfVariableIndices())
+    objective_sense = MOI.get(sampler, MOI.ObjectiveSense())
+
+    config!(sampler)
+
+    solve = @timed MOI.optimize!(sampler)
+
+    result_count = MOI.get(sampler, MOI.ResultCount())
+    objective_values = Vector{T}(undef, result_count)
+
+    for i = 1:result_count
+        objective_values[i] = MOI.get(sampler, MOI.ObjectiveValue(i))
+    end
+
+    objective_summary = _benchmark_objective_summary(objective_values)
+    best_index = _best_benchmark_index(objective_values, objective_sense)
+    best_objective = isnothing(best_index) ? nothing : objective_values[best_index]
+    best_state = if isnothing(best_index)
+        nothing
+    else
+        MOI.get.(sampler, MOI.VariablePrimal(best_index), variables)
+    end
+
+    return (;
+        solver             = MOI.get(sampler, MOI.SolverName()),
+        version            = MOI.get(sampler, MOI.SolverVersion()),
+        objective_sense,
+        variables          = length(variables),
+        result_count,
+        objective_values,
+        objective_summary,
+        best_index,
+        best_objective,
+        best_state,
+        solve_time         = MOI.get(sampler, MOI.SolveTimeSec()),
+        wall_time          = solve.time,
+        termination_status = MOI.get(sampler, MOI.TerminationStatus()),
+        raw_status         = MOI.get(sampler, MOI.RawStatusString()),
+    )
+end
+
+function _validate_benchmark_sense(objective_sense)
+    if !(objective_sense == MOI.MIN_SENSE || objective_sense == MOI.MAX_SENSE)
+        throw(ArgumentError("benchmark objective_sense must be MOI.MIN_SENSE or MOI.MAX_SENSE"))
+    end
+
+    return nothing
+end
+
+function _best_benchmark_index(objective_values::AbstractVector, objective_sense)
+    isempty(objective_values) && return nothing
+
+    return objective_sense == MOI.MAX_SENSE ? argmax(objective_values) : argmin(objective_values)
+end
+
+function _benchmark_objective_summary(objective_values::AbstractVector{T}) where {T}
+    histogram = Dict{T,Int}()
+    total = zero(T)
+
+    for value in objective_values
+        histogram[value] = get(histogram, value, 0) + 1
+        total += value
+    end
+
+    if isempty(objective_values)
+        return (; minimum = nothing, maximum = nothing, mean = nothing, histogram)
+    end
+
+    return (;
+        minimum = minimum(objective_values),
+        maximum = maximum(objective_values),
+        mean    = total / length(objective_values),
+        histogram,
+    )
+end
+
+function _default_benchmark_model(::Type{T}, objective_sense) where {T}
+    model = MOI.Utilities.Model{T}()
+    Q = T[-1 2 2; 2 -1 2; 2 2 -1]
+    n = size(Q, 1)
+    x, _ = MOI.add_constrained_variables(model, fill(MOI.ZeroOne(), n))
+
+    MOI.set(model, MOI.ObjectiveSense(), objective_sense)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{SQF{T}}(),
+        SQF{T}(
+            SQT{T}[SQT{T}(Q[i, j], x[i], x[j]) for i = 1:n for j = 1:n if i != j],
+            SAT{T}[SAT{T}(Q[i, i], x[i]) for i = 1:n],
+            zero(T),
+        ),
+    )
+
+    return model
+end

--- a/src/interface/benchmark.jl
+++ b/src/interface/benchmark.jl
@@ -14,9 +14,9 @@ source model is copied and before optimization. This is useful for setting
 sampler attributes such as seeds, number of reads, time limits, or warm-starts.
 
 The return value is a named tuple with solver metadata, benchmark problem size,
-result count, objective values, objective-value summary statistics, the best
-result, MOI solve time, measured wall time around `MOI.optimize!`, and solver
-status fields.
+result count, objective values, read counts, objective-value summary
+statistics, the best result, MOI solve time, measured wall time around
+`MOI.optimize!`, and solver status fields.
 """
 function benchmark end
 
@@ -64,12 +64,14 @@ function benchmark(
 
     result_count = MOI.get(sampler, MOI.ResultCount())
     objective_values = Vector{T}(undef, result_count)
+    read_counts = Vector{Int}(undef, result_count)
 
     for i = 1:result_count
         objective_values[i] = MOI.get(sampler, MOI.ObjectiveValue(i))
+        read_counts[i] = MOI.get(sampler, QUBOTools_MOI.NumberOfReads(i))
     end
 
-    objective_summary = _benchmark_objective_summary(objective_values)
+    objective_summary = _benchmark_objective_summary(objective_values, read_counts)
     best_index = _best_benchmark_index(objective_values, objective_sense)
     best_objective = isnothing(best_index) ? nothing : objective_values[best_index]
     best_state = if isnothing(best_index)
@@ -85,6 +87,7 @@ function benchmark(
         variables          = length(variables),
         result_count,
         objective_values,
+        read_counts,
         objective_summary,
         best_index,
         best_objective,
@@ -110,23 +113,32 @@ function _best_benchmark_index(objective_values::AbstractVector, objective_sense
     return objective_sense == MOI.MAX_SENSE ? argmax(objective_values) : argmin(objective_values)
 end
 
-function _benchmark_objective_summary(objective_values::AbstractVector{T}) where {T}
+function _benchmark_objective_summary(
+    objective_values::AbstractVector{T},
+    read_counts::AbstractVector{<:Integer},
+) where {T}
+    length(objective_values) == length(read_counts) ||
+        throw(ArgumentError("objective_values and read_counts must have the same length"))
+
     histogram = Dict{T,Int}()
     total = zero(T)
+    total_reads = 0
 
-    for value in objective_values
-        histogram[value] = get(histogram, value, 0) + 1
-        total += value
+    for (value, reads) in zip(objective_values, read_counts)
+        histogram[value] = get(histogram, value, 0) + reads
+        total += value * reads
+        total_reads += reads
     end
 
-    if isempty(objective_values)
-        return (; minimum = nothing, maximum = nothing, mean = nothing, histogram)
+    if isempty(objective_values) || iszero(total_reads)
+        return (; minimum = nothing, maximum = nothing, mean = nothing, total_reads, histogram)
     end
 
     return (;
         minimum = minimum(objective_values),
         maximum = maximum(objective_values),
-        mean    = total / length(objective_values),
+        mean    = total / total_reads,
+        total_reads,
         histogram,
     )
 end

--- a/test/drivers/benchmark.jl
+++ b/test/drivers/benchmark.jl
@@ -27,9 +27,11 @@ function test_benchmark_helper()
         @test exact.variables == 3
         @test exact.result_count == 8
         @test length(exact.objective_values) == exact.result_count
+        @test exact.read_counts == ones(Int, exact.result_count)
         @test exact.objective_summary.minimum == minimum(exact.objective_values)
         @test exact.objective_summary.maximum == maximum(exact.objective_values)
         @test exact.objective_summary.mean ≈ sum(exact.objective_values) / exact.result_count
+        @test exact.objective_summary.total_reads == sum(exact.read_counts)
         @test sum(values(exact.objective_summary.histogram)) == exact.result_count
         @test exact.best_objective ≈ -1.0
         @test exact.best_index in 1:exact.result_count
@@ -49,13 +51,30 @@ function test_benchmark_helper()
         @test random.solver == "Random Sampler"
         @test random.result_count == 1
         @test length(random.objective_values) == random.result_count
+        @test random.read_counts == [1]
         @test random.objective_summary.minimum == only(random.objective_values)
         @test random.objective_summary.maximum == only(random.objective_values)
         @test random.objective_summary.mean == only(random.objective_values)
+        @test random.objective_summary.total_reads == 1
         @test random.objective_summary.histogram == Dict(only(random.objective_values) => 1)
         @test random.best_index in 1:random.result_count
         @test random.best_objective == minimum(random.objective_values)
         @test length(random.best_state) == random.variables
+
+        random_many = QUBODrivers.benchmark(RandomSampler.Optimizer) do model
+            MOI.set(model, MOI.RawOptimizerAttribute("num_reads"), 100)
+            MOI.set(model, MOI.RawOptimizerAttribute("seed"), 1)
+        end
+
+        @test random_many.result_count <= 100
+        @test sum(random_many.read_counts) == 100
+        @test random_many.objective_summary.total_reads == 100
+        @test sum(values(random_many.objective_summary.histogram)) == 100
+        @test random_many.objective_summary.mean ≈
+              sum(
+                  value * reads for
+                  (value, reads) in zip(random_many.objective_values, random_many.read_counts)
+              ) / 100
 
         empty_random = QUBODrivers.benchmark(RandomSampler.Optimizer) do model
             MOI.set(model, MOI.RawOptimizerAttribute("num_reads"), 0)
@@ -64,9 +83,11 @@ function test_benchmark_helper()
 
         @test empty_random.result_count == 0
         @test isempty(empty_random.objective_values)
+        @test isempty(empty_random.read_counts)
         @test empty_random.objective_summary.minimum === nothing
         @test empty_random.objective_summary.maximum === nothing
         @test empty_random.objective_summary.mean === nothing
+        @test empty_random.objective_summary.total_reads == 0
         @test isempty(empty_random.objective_summary.histogram)
         @test empty_random.best_index === nothing
         @test empty_random.best_objective === nothing
@@ -83,8 +104,10 @@ function test_benchmark_helper()
 
         @test custom.variables == 2
         @test custom.result_count == 4
+        @test custom.read_counts == ones(Int, custom.result_count)
         @test custom.objective_summary.minimum ≈ -1.0
         @test custom.objective_summary.maximum ≈ 2.0
+        @test custom.objective_summary.total_reads == 4
         @test custom.best_objective ≈ -1.0
         @test custom.best_state ≈ [1.0, 0.0]
 

--- a/test/drivers/benchmark.jl
+++ b/test/drivers/benchmark.jl
@@ -1,0 +1,108 @@
+function _benchmark_source_model(::Type{T} = Float64) where {T}
+    model = MOI.Utilities.Model{T}()
+    x, _ = MOI.add_constrained_variables(model, fill(MOI.ZeroOne(), 2))
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}(),
+        MOI.ScalarAffineFunction{T}(
+            MOI.ScalarAffineTerm{T}[
+                MOI.ScalarAffineTerm{T}(-one(T), x[1]),
+                MOI.ScalarAffineTerm{T}(2one(T), x[2]),
+            ],
+            zero(T),
+        ),
+    )
+
+    return model
+end
+
+function test_benchmark_helper()
+    @testset "□ Benchmark Helper" begin
+        exact = QUBODrivers.benchmark(ExactSampler.Optimizer)
+
+        @test exact.solver == "Exact Sampler"
+        @test exact.objective_sense == MOI.MIN_SENSE
+        @test exact.variables == 3
+        @test exact.result_count == 8
+        @test length(exact.objective_values) == exact.result_count
+        @test exact.objective_summary.minimum == minimum(exact.objective_values)
+        @test exact.objective_summary.maximum == maximum(exact.objective_values)
+        @test exact.objective_summary.mean ≈ sum(exact.objective_values) / exact.result_count
+        @test sum(values(exact.objective_summary.histogram)) == exact.result_count
+        @test exact.best_objective ≈ -1.0
+        @test exact.best_index in 1:exact.result_count
+        @test exact.best_state ≈ [0.0, 0.0, 1.0] ||
+              exact.best_state ≈ [0.0, 1.0, 0.0] ||
+              exact.best_state ≈ [1.0, 0.0, 0.0]
+        @test exact.solve_time >= 0
+        @test exact.wall_time >= 0
+        @test exact.termination_status == MOI.LOCALLY_SOLVED
+        @test exact.raw_status == "optimal"
+
+        random = QUBODrivers.benchmark(RandomSampler.Optimizer) do model
+            MOI.set(model, MOI.RawOptimizerAttribute("num_reads"), 1)
+            MOI.set(model, MOI.RawOptimizerAttribute("seed"), 1)
+        end
+
+        @test random.solver == "Random Sampler"
+        @test random.result_count == 1
+        @test length(random.objective_values) == random.result_count
+        @test random.objective_summary.minimum == only(random.objective_values)
+        @test random.objective_summary.maximum == only(random.objective_values)
+        @test random.objective_summary.mean == only(random.objective_values)
+        @test random.objective_summary.histogram == Dict(only(random.objective_values) => 1)
+        @test random.best_index in 1:random.result_count
+        @test random.best_objective == minimum(random.objective_values)
+        @test length(random.best_state) == random.variables
+
+        empty_random = QUBODrivers.benchmark(RandomSampler.Optimizer) do model
+            MOI.set(model, MOI.RawOptimizerAttribute("num_reads"), 0)
+            MOI.set(model, MOI.RawOptimizerAttribute("seed"), 1)
+        end
+
+        @test empty_random.result_count == 0
+        @test isempty(empty_random.objective_values)
+        @test empty_random.objective_summary.minimum === nothing
+        @test empty_random.objective_summary.maximum === nothing
+        @test empty_random.objective_summary.mean === nothing
+        @test isempty(empty_random.objective_summary.histogram)
+        @test empty_random.best_index === nothing
+        @test empty_random.best_objective === nothing
+        @test empty_random.best_state === nothing
+
+        max_exact = QUBODrivers.benchmark(ExactSampler.Optimizer; objective_sense = MOI.MAX_SENSE)
+
+        @test max_exact.objective_sense == MOI.MAX_SENSE
+        @test max_exact.best_objective ≈ 9.0
+        @test max_exact.best_state ≈ [1.0, 1.0, 1.0]
+
+        source = _benchmark_source_model()
+        custom = QUBODrivers.benchmark(ExactSampler.Optimizer, source)
+
+        @test custom.variables == 2
+        @test custom.result_count == 4
+        @test custom.objective_summary.minimum ≈ -1.0
+        @test custom.objective_summary.maximum ≈ 2.0
+        @test custom.best_objective ≈ -1.0
+        @test custom.best_state ≈ [1.0, 0.0]
+
+        configured_raw_sampler = Ref(false)
+        configured = QUBODrivers.benchmark(IdentitySampler.Optimizer, source) do sampler
+            configured_raw_sampler[] = sampler isa IdentitySampler.Optimizer{Float64}
+            @test MOI.get(sampler, MOI.NumberOfVariables()) == 2
+
+            x = MOI.get(sampler, MOI.ListOfVariableIndices())
+            MOI.set(sampler, MOI.VariablePrimalStart(), x[1], 1.0)
+            MOI.set(sampler, MOI.VariablePrimalStart(), x[2], 0.0)
+        end
+
+        @test configured_raw_sampler[]
+        @test configured.result_count == 1
+        @test configured.best_objective ≈ -1.0
+        @test configured.best_state ≈ [1.0, 0.0]
+    end
+
+    return nothing
+end

--- a/test/drivers/sampler_bundle.jl
+++ b/test/drivers/sampler_bundle.jl
@@ -1,12 +1,14 @@
 include("exact_sampler.jl")
 include("identity_sampler.jl")
 include("random_sampler.jl")
+include("benchmark.jl")
 
 function test_sampler_bundle()
     @testset "□ Utility Samplers Bundle" verbose = true begin
         test_exact_sampler()
         test_identiy_sampler()
         test_random_sampler()
+        test_benchmark_helper()
     end
 
     return nothing


### PR DESCRIPTION
## Summary

- Add `QUBODrivers.benchmark` for direct sampler benchmark smoke tests.
- Support benchmarking caller-provided `MOI.ModelLike` problems, with a small built-in QUBO retained as the no-model smoke fallback.
- Apply the optional `do`-block configuration to the raw sampler optimizer after model copy and before optimization.
- Return solver metadata, objective values, objective summary statistics, best result, timing, and status fields.
- Document the helper with MOI and JuMP examples, including `backend(model)` for user-built JuMP problems.
- Add regression coverage for exact, random, identity, min/max, configured sampler use, caller-provided benchmark models, objective summaries, and empty random samples.

## Tests run

- `julia +release --project=. -e 'using Test, QUBODrivers; using QUBODrivers: MOI; include("test/drivers/benchmark.jl"); test_benchmark_helper()'` - passed, 49 tests.
- `julia +release --project=. -e 'using Pkg; Pkg.test()'` - passed, 573 tests.
- `julia +release --project=docs/ docs/make.jl --skip-deploy` - passed.
- `julia +release --project=docs -e 'using JuMP, QUBODrivers; model = Model(); @variable(model, x[1:3], Bin); @objective(model, Min, -x[1]-x[2]-x[3]+2x[1]*x[2]); r = QUBODrivers.benchmark(RandomSampler.Optimizer, backend(model)) do sampler; MOI.set(sampler, MOI.RawOptimizerAttribute("num_reads"), 5); MOI.set(sampler, MOI.RawOptimizerAttribute("seed"), 1); end; @show r.variables r.result_count r.best_objective'` - passed.
- `git diff --check` - passed.
- Previously on this branch: `bash .github/tests/doc_preview_cleanup.sh`, `python -m unittest discover -s .github/tests -p "test_*.py"`, and `actionlint` - passed.

## Notes about tests not run

- A local Julia 1.10 package-suite attempt against this workspace's untracked root `Manifest.toml` failed before loading QUBODrivers because that manifest is resolved with Julia 1.12-era dependencies. The tracked project state does not include that manifest.

Closes #1
