### PR TITLE
Add MOI-native MIP sampler baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ end
 
 | Package                                                           |  Solvers                                         |
 | :---------------------------------------------------------------- | :----------------------------------------------- |
-| [`QUBODrivers.jl`](https://github.com/JuliaQUBO/QUBODrivers.jl)   | `ExactSampler` `RandomSampler` `IdentitySampler` |
+| [`QUBODrivers.jl`](https://github.com/JuliaQUBO/QUBODrivers.jl)   | `ExactSampler` `RandomSampler` `IdentitySampler` `MIPSampler` |
 | [`QiskitOpt.jl`](https://github.com/JuliaQUBO/QiskitOpt.jl)       | `QiskitOpt.QAOA` `QiskitOpt.VQE`                 |
 | [`DWave.jl`](https://github.com/JuliaQUBO/DWave.jl)               | `DWave` `DWave.Neal`                             |
 | [`PySA.jl`](https://github.com/JuliaQUBO/PySA.jl)                 | `PySA`                                           |

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,8 +9,8 @@ samplers and annealing backends.
 
 The package includes:
 
-- utility samplers for exact enumeration, random sampling, and warm-start
-  identity sampling;
+- utility samplers for exact enumeration, random sampling, warm-start identity
+  sampling, and MIP-backed baseline solving;
 - a macro for declaring sampler optimizers and user-facing attributes;
 - MOI and QUBOTools plumbing for model conversion and result access;
 - a reusable test suite for sampler implementations.

--- a/docs/src/manual/3-samplers.md
+++ b/docs/src/manual/3-samplers.md
@@ -1,14 +1,15 @@
 # Samplers
 
-QUBODrivers includes three utility samplers. They are intentionally simple:
+QUBODrivers includes four utility samplers. They are intentionally simple:
 their main role is to exercise the interface, provide small-instance baselines,
-and make examples runnable without external services.
+and make examples runnable without external services or fixed solver choices.
 
 | Sampler | Purpose | Main result behavior |
 | :-- | :-- | :-- |
 | [`ExactSampler.Optimizer`](@ref) | Exhaustive enumeration for small models | returns every state |
 | [`RandomSampler.Optimizer`](@ref) | Random baseline and smoke tests | returns `num_reads` random states |
 | [`IdentitySampler.Optimizer`](@ref) | Warm-start and conversion checks | returns the provided start state |
+| [`MIPSampler.Optimizer`](@ref) | Exact MIP-backed baseline using a user-supplied MOI optimizer | returns one best incumbent |
 
 ## Exact Sampler
 
@@ -99,6 +100,42 @@ MOI.optimize!(model)
 
 ```@docs
 QUBODrivers.IdentitySampler.Optimizer
+```
+
+## MIP Sampler
+
+Use `MIPSampler` as an exact correctness baseline for small and medium QUBO
+instances when you want to choose the MIP backend yourself. The sampler is
+implemented directly against MathOptInterface and does not depend on JuMP or on
+any concrete MIP solver package.
+
+```julia
+using JuMP
+using QUBODrivers
+using GLPK
+
+model = Model(MIPSampler.Optimizer)
+set_attribute(model, MIPSampler.MIPOptimizer(), GLPK.Optimizer)
+
+@variable(model, x[1:3], Bin)
+@objective(model, Min, x[1] + x[2] - 2x[1] * x[3])
+
+optimize!(model)
+
+value.(x)
+objective_value(model)
+```
+
+Internally, `MIPSampler` linearizes binary products with auxiliary variables
+and the standard Fortet/McCormick inequalities. The reformulation is a baseline
+route, not a replacement for specialized large-scale QUBO heuristics. For a
+broader discussion of efficient binary polynomial reformulations, see Elloumi,
+Sourour, and Verchere, "Efficient linear reformulations for binary polynomial
+optimization problems", Computers & Operations Research 155 (2023), 106240.
+
+```@docs
+QUBODrivers.MIPSampler.Optimizer
+QUBODrivers.MIPSampler.MIPOptimizer
 ```
 
 ## External Sampler Packages

--- a/docs/src/manual/8-api.md
+++ b/docs/src/manual/8-api.md
@@ -36,6 +36,8 @@ QUBODrivers.default_raw_attr
 QUBODrivers.ExactSampler.Optimizer
 QUBODrivers.RandomSampler.Optimizer
 QUBODrivers.IdentitySampler.Optimizer
+QUBODrivers.MIPSampler.Optimizer
+QUBODrivers.MIPSampler.MIPOptimizer
 ```
 
 ## Test and Benchmark Helpers

--- a/src/QUBODrivers.jl
+++ b/src/QUBODrivers.jl
@@ -7,8 +7,8 @@ Common MathOptInterface-compatible tools for QUBO and Ising samplers.
 
 - an [`AbstractSampler`](@ref) optimizer interface for QUBO-oriented solvers;
 - the [`@setup`](@ref) macro for declaring sampler optimizers and attributes;
-- built-in utility samplers in `ExactSampler`, `RandomSampler`, and
-  `IdentitySampler`;
+- built-in utility samplers in `ExactSampler`, `RandomSampler`,
+  `IdentitySampler`, and `MIPSampler`;
 - result and model plumbing through MathOptInterface and QUBOTools;
 - optional [`test`](@ref) and [`benchmark`](@ref) helpers for sampler
   implementations.
@@ -49,10 +49,11 @@ include("library/setup/quote.jl")
 include("library/setup/macro.jl")
 
 export AbstractSampler
-export ExactSampler, IdentitySampler, RandomSampler
+export ExactSampler, IdentitySampler, MIPSampler, RandomSampler
 
 include("library/drivers/ExactSampler.jl")
 include("library/drivers/IdentitySampler.jl")
+include("library/drivers/MIPSampler.jl")
 include("library/drivers/RandomSampler.jl")
 
 end # module QUBODrivers

--- a/src/library/drivers/MIPSampler.jl
+++ b/src/library/drivers/MIPSampler.jl
@@ -1,0 +1,306 @@
+module MIPSampler
+
+import QUBOTools
+import QUBODrivers
+import QUBODrivers: MOI, Sample, SampleSet
+
+const SAF{T} = MOI.ScalarAffineFunction{T}
+const SAT{T} = MOI.ScalarAffineTerm{T}
+
+@doc raw"""
+    MIPSampler.Optimizer{T}
+
+MOI-native exact baseline that linearizes a QUBO into a binary mixed-integer
+linear model and solves it with a user-supplied MOI optimizer.
+
+`MIPSampler` does not depend on any concrete MIP solver. Set
+[`MIPOptimizer`](@ref) to a compatible optimizer factory, such as
+`HiGHS.Optimizer`, `GLPK.Optimizer`, or
+`MOI.OptimizerWithAttributes(HiGHS.Optimizer, MOI.Silent() => true)`.
+
+The sampler introduces one binary auxiliary variable for each off-diagonal
+quadratic term and enforces the product relation with the standard
+Fortet/McCormick inequalities. This follows the usual linear reformulation
+route for binary polynomial optimization; see also Elloumi, Sourour, and
+Verchere, "Efficient linear reformulations for binary polynomial optimization
+problems", Computers & Operations Research 155 (2023), 106240.
+
+Only one best incumbent sample is returned.
+
+## Attributes
+- `MIPOptimizer`, `"mip_optimizer"`: MOI-compatible optimizer factory used to
+  solve the generated binary MIP.
+"""
+QUBODrivers.@setup Optimizer begin
+    name       = "MIP Sampler"
+    version    = QUBODrivers.__version__()
+    attributes = begin
+        MIPOptimizer["mip_optimizer"]::Any = nothing
+    end
+end
+
+@doc raw"""
+    MIPOptimizer()
+
+Optimizer attribute that stores the MOI-compatible MIP backend factory used by
+[`MIPSampler.Optimizer`](@ref).
+"""
+MIPOptimizer
+
+const _RawMIPOptimizer = QUBODrivers.RawSamplerAttribute{Symbol("mip_optimizer")}
+
+MOI.Utilities.map_indices(_, ::MIPOptimizer, value) = value
+MOI.Utilities.map_indices(_, ::_RawMIPOptimizer, value) = value
+
+function _require_mip_optimizer(sampler::Optimizer)
+    optimizer = MOI.get(sampler, MIPOptimizer())
+
+    if isnothing(optimizer)
+        throw(
+            ArgumentError(
+                "MIPSampler requires a MIP optimizer factory. Set " *
+                "`MIPSampler.MIPOptimizer()` to an MOI-compatible optimizer, " *
+                "for example `HiGHS.Optimizer`, `GLPK.Optimizer`, or " *
+                "`MOI.OptimizerWithAttributes(HiGHS.Optimizer, MOI.Silent() => true)`.",
+            ),
+        )
+    end
+
+    return optimizer
+end
+
+function _instantiate_backend(optimizer, ::Type{T}) where {T}
+    try
+        return MOI.instantiate(optimizer; with_bridge_type = T)
+    catch err
+        msg = sprint(showerror, err)
+
+        throw(ArgumentError("Could not instantiate MIP optimizer factory: $msg"))
+    end
+end
+
+function _supports_attribute(backend, attr)::Bool
+    try
+        return MOI.supports(backend, attr)
+    catch
+        return false
+    end
+end
+
+function _has_sampler_attribute(sampler::Optimizer, raw_name::String)
+    return haskey(sampler.attributes, Symbol(raw_name))
+end
+
+function _forward_attribute!(
+    forwarded::Vector{String},
+    backend,
+    sampler::Optimizer,
+    attr,
+    raw_name::String,
+    label::String;
+    skip_nothing::Bool = false,
+)
+    _has_sampler_attribute(sampler, raw_name) || return nothing
+    _supports_attribute(backend, attr) || return nothing
+
+    value = MOI.get(sampler, attr)
+
+    if skip_nothing && isnothing(value)
+        return nothing
+    end
+
+    MOI.set(backend, attr, value)
+    push!(forwarded, label)
+
+    return nothing
+end
+
+function _forward_common_attributes!(backend, sampler::Optimizer)
+    forwarded = String[]
+
+    _forward_attribute!(
+        forwarded,
+        backend,
+        sampler,
+        MOI.TimeLimitSec(),
+        "moi/timelimitsec",
+        "MOI.TimeLimitSec";
+        skip_nothing = true,
+    )
+    _forward_attribute!(
+        forwarded,
+        backend,
+        sampler,
+        MOI.NumberOfThreads(),
+        "moi/numberofthreads",
+        "MOI.NumberOfThreads",
+    )
+    _forward_attribute!(
+        forwarded,
+        backend,
+        sampler,
+        MOI.Silent(),
+        "moi/silent",
+        "MOI.Silent",
+    )
+
+    return forwarded
+end
+
+_affine(::Type{T}, terms::Vector{SAT{T}}, constant::T = zero(T)) where {T} =
+    SAF{T}(terms, constant)
+
+function _add_binary_variable(backend)
+    x = MOI.add_variable(backend)
+
+    MOI.add_constraint(backend, x, MOI.ZeroOne())
+
+    return x
+end
+
+function _add_product_variable!(
+    objective_terms::Vector{SAT{T}},
+    backend,
+    x,
+    i::Integer,
+    j::Integer,
+    coefficient::T,
+) where {T}
+    y = _add_binary_variable(backend)
+
+    MOI.add_constraint(
+        backend,
+        _affine(
+            T,
+            SAT{T}[SAT{T}(one(T), y), SAT{T}(-one(T), x[i]), SAT{T}(-one(T), x[j])],
+        ),
+        MOI.GreaterThan(-one(T)),
+    )
+    MOI.add_constraint(
+        backend,
+        _affine(T, SAT{T}[SAT{T}(one(T), y), SAT{T}(-one(T), x[i])]),
+        MOI.LessThan(zero(T)),
+    )
+    MOI.add_constraint(
+        backend,
+        _affine(T, SAT{T}[SAT{T}(one(T), y), SAT{T}(-one(T), x[j])]),
+        MOI.LessThan(zero(T)),
+    )
+
+    push!(objective_terms, SAT{T}(coefficient, y))
+
+    return y
+end
+
+function _build_mip_model!(backend, n::Integer, L, Q, α::T, β::T) where {T}
+    x = [_add_binary_variable(backend) for _ in 1:n]
+    objective_terms = SAT{T}[]
+
+    for (i, value) in L
+        coefficient = convert(T, α * value)
+
+        if !iszero(coefficient)
+            push!(objective_terms, SAT{T}(coefficient, x[i]))
+        end
+    end
+
+    for ((i, j), value) in Q
+        coefficient = convert(T, α * value)
+
+        if iszero(coefficient)
+            continue
+        elseif i == j
+            push!(objective_terms, SAT{T}(coefficient, x[i]))
+        else
+            _add_product_variable!(objective_terms, backend, x, i, j, coefficient)
+        end
+    end
+
+    MOI.set(backend, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(
+        backend,
+        MOI.ObjectiveFunction{SAF{T}}(),
+        _affine(T, objective_terms, convert(T, α * β)),
+    )
+
+    return x
+end
+
+function _has_primal_solution(status)
+    return status == MOI.FEASIBLE_POINT || status == MOI.NEARLY_FEASIBLE_POINT
+end
+
+function _solution_state(backend, x)
+    return Int[MOI.get(backend, MOI.VariablePrimal(), xi) >= 0.5 ? 1 : 0 for xi in x]
+end
+
+function _backend_attribute(backend, attr)
+    try
+        return MOI.get(backend, attr)
+    catch
+        return nothing
+    end
+end
+
+function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
+    optimizer = _require_mip_optimizer(sampler)
+    n, L, Q, α, β = QUBOTools.qubo(sampler, :dict; sense = :min, domain = :bool)
+
+    build_results = @timed begin
+        backend = _instantiate_backend(optimizer, T)
+        forwarded_attributes = _forward_common_attributes!(backend, sampler)
+        x = _build_mip_model!(backend, n, L, Q, α, β)
+
+        (backend, x, forwarded_attributes)
+    end
+    backend, x, forwarded_attributes = build_results.value
+
+    solve_results = @timed MOI.optimize!(backend)
+    termination_status = MOI.get(backend, MOI.TerminationStatus())
+    primal_status = MOI.get(backend, MOI.PrimalStatus())
+
+    if !_has_primal_solution(primal_status)
+        error(
+            "MIP backend did not return a feasible primal solution " *
+            "(termination_status = $(termination_status), primal_status = $(primal_status))",
+        )
+    end
+
+    ψ = _solution_state(backend, x)
+    λ = QUBOTools.value(ψ, L, Q, α, β)
+    sample = Sample{T,Int}(ψ, λ)
+
+    metadata = Dict{String,Any}(
+        "origin"             => "MIP Sampler @ QUBODrivers.jl",
+        "backend"            => Dict{String,Any}(
+            "name"    => _backend_attribute(backend, MOI.SolverName()),
+            "version" => _backend_attribute(backend, MOI.SolverVersion()),
+        ),
+        "time"               => Dict{String,Any}(
+            "build"     => build_results.time,
+            "effective" => solve_results.time,
+        ),
+        "status"             => string(termination_status),
+        "termination_status" => termination_status,
+        "primal_status"      => primal_status,
+        "attributes"         => Dict{String,Any}("forwarded" => forwarded_attributes),
+    )
+
+    return SampleSet{T}([sample], metadata; sense = :min, domain = :bool)
+end
+
+function MOI.get(sampler::Optimizer{T}, ::MOI.TerminationStatus) where {T}
+    ω = QUBOTools.solution(sampler)
+    metadata = QUBOTools.metadata(ω)
+    status = get(metadata, "termination_status", nothing)
+
+    if status isa MOI.TerminationStatusCode
+        return status
+    elseif isempty(ω)
+        return isempty(metadata) ? MOI.OPTIMIZE_NOT_CALLED : MOI.OTHER_ERROR
+    else
+        return MOI.LOCALLY_SOLVED
+    end
+end
+
+end # module

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,8 @@
 [deps]
+GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+GLPK = "1"
 PythonCall = "0.9"

--- a/test/drivers/mip_sampler.jl
+++ b/test/drivers/mip_sampler.jl
@@ -13,10 +13,10 @@ function _config_mip_sampler!(model)
     return nothing
 end
 
-function _build_mip_test_model(::Type{T}, n::Integer) where {T}
+function _build_mip_test_model(::Type{T}, n::Integer; optimizer = MIP_TEST_OPTIMIZER) where {T}
     model = MOI.instantiate(MIPSampler.Optimizer; with_bridge_type = T)
 
-    MOI.set(model, MIPSampler.MIPOptimizer(), MIP_TEST_OPTIMIZER)
+    MOI.set(model, MIPSampler.MIPOptimizer(), optimizer)
 
     x, _ = MOI.add_constrained_variables(model, fill(MOI.ZeroOne(), n))
 
@@ -64,6 +64,24 @@ function _test_mip_sampler_linear_only()
         MOI.optimize!(model)
 
         _assert_single_solution(model, x, [0, 1, 0], -3.0)
+    end
+
+    return nothing
+end
+
+function _test_mip_sampler_plain_optimizer_factory()
+    @testset "Plain optimizer factory" begin
+        model, x = _build_mip_test_model(Float64, 2; optimizer = GLPK.Optimizer)
+        f = MIP_SQF{Float64}(
+            MIP_SQT{Float64}[MIP_SQT{Float64}(-3.0, x[1], x[2])],
+            MIP_SAT{Float64}[],
+            0.0,
+        )
+
+        MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+        MOI.optimize!(model)
+
+        _assert_single_solution(model, x, [1, 1], -3.0)
     end
 
     return nothing
@@ -140,6 +158,7 @@ function test_mip_sampler()
     @testset "□ MIPSampler" verbose = true begin
         _test_mip_sampler_missing_optimizer()
         _test_mip_sampler_linear_only()
+        _test_mip_sampler_plain_optimizer_factory()
         _test_mip_sampler_quadratic_only()
         _test_mip_sampler_mixed_quadratic_signs()
         _test_mip_sampler_attribute_forwarding()

--- a/test/drivers/mip_sampler.jl
+++ b/test/drivers/mip_sampler.jl
@@ -6,6 +6,74 @@ const MIP_SQF{T} = MOI.ScalarQuadraticFunction{T}
 const MIP_SQT{T} = MOI.ScalarQuadraticTerm{T}
 
 const MIP_TEST_OPTIMIZER = MOI.OptimizerWithAttributes(GLPK.Optimizer, MOI.Silent() => true)
+const MIP_PARITY_CASES = [
+    (
+        name = "bool linear",
+        n = 3,
+        domain = :bool,
+        sense = MOI.MIN_SENSE,
+        affine = [(2.0, 1), (-3.0, 2), (1.0, 3)],
+        quadratic = Tuple{Float64,Int,Int}[],
+        constant = 0.0,
+        expected_state = [0, 1, 0],
+        expected_value = -3.0,
+    ),
+    (
+        name = "bool quadratic only",
+        n = 2,
+        domain = :bool,
+        sense = MOI.MIN_SENSE,
+        affine = Tuple{Float64,Int}[],
+        quadratic = [(-3.0, 1, 2)],
+        constant = 0.0,
+        expected_state = [1, 1],
+        expected_value = -3.0,
+    ),
+    (
+        name = "bool mixed signs",
+        n = 3,
+        domain = :bool,
+        sense = MOI.MIN_SENSE,
+        affine = [(1.0, 1), (1.0, 2)],
+        quadratic = [(-2.0, 1, 3), (3.0, 2, 3), (-1.0, 1, 2)],
+        constant = 0.0,
+        expected_state = [1, 0, 1],
+        expected_value = -1.0,
+    ),
+    (
+        name = "bool constant offset",
+        n = 2,
+        domain = :bool,
+        sense = MOI.MIN_SENSE,
+        affine = [(2.0, 1), (-3.0, 2)],
+        quadratic = [(2.0, 1, 2)],
+        constant = 4.5,
+        expected_state = [0, 1],
+        expected_value = 1.5,
+    ),
+    (
+        name = "bool max sense",
+        n = 2,
+        domain = :bool,
+        sense = MOI.MAX_SENSE,
+        affine = [(-1.0, 1), (2.0, 2)],
+        quadratic = [(3.0, 1, 2)],
+        constant = 0.0,
+        expected_state = [1, 1],
+        expected_value = 4.0,
+    ),
+    (
+        name = "spin affine quadratic",
+        n = 2,
+        domain = :spin,
+        sense = MOI.MIN_SENSE,
+        affine = [(1.0, 1), (-2.0, 2)],
+        quadratic = [(1.5, 1, 2)],
+        constant = -0.25,
+        expected_state = [-1, 1],
+        expected_value = -4.75,
+    ),
+]
 
 function _config_mip_sampler!(model)
     MOI.set(model, MIPSampler.MIPOptimizer(), MIP_TEST_OPTIMIZER)
@@ -25,11 +93,88 @@ function _build_mip_test_model(::Type{T}, n::Integer; optimizer = MIP_TEST_OPTIM
     return model, x
 end
 
+function _add_mip_parity_variables(model, case)
+    sets = if case.domain === :bool
+        fill(MOI.ZeroOne(), case.n)
+    else
+        fill(QUBODrivers.Spin(), case.n)
+    end
+
+    x, _ = MOI.add_constrained_variables(model, sets)
+
+    return x
+end
+
+function _set_mip_parity_objective!(model, x, case)
+    affine_terms = MIP_SAT{Float64}[
+        MIP_SAT{Float64}(coefficient, x[i]) for (coefficient, i) in case.affine
+    ]
+
+    if isempty(case.quadratic)
+        f = MIP_SAF{Float64}(affine_terms, case.constant)
+    else
+        quadratic_terms = MIP_SQT{Float64}[
+            MIP_SQT{Float64}(coefficient, x[i], x[j]) for
+            (coefficient, i, j) in case.quadratic
+        ]
+        f = MIP_SQF{Float64}(quadratic_terms, affine_terms, case.constant)
+    end
+
+    MOI.set(model, MOI.ObjectiveSense(), case.sense)
+    MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+
+    return nothing
+end
+
+function _build_mip_parity_model(optimizer, case)
+    model = MOI.instantiate(optimizer; with_bridge_type = Float64)
+
+    if optimizer === MIPSampler.Optimizer
+        MOI.set(model, MIPSampler.MIPOptimizer(), GLPK.Optimizer)
+    end
+
+    x = _add_mip_parity_variables(model, case)
+    _set_mip_parity_objective!(model, x, case)
+
+    return model, x
+end
+
+function _best_exact_value(model)
+    values = [MOI.get(model, MOI.ObjectiveValue(i)) for i in 1:MOI.get(model, MOI.ResultCount())]
+
+    return MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE ? minimum(values) :
+           maximum(values)
+end
+
 function _assert_single_solution(model, x, expected_state, expected_value)
     @test MOI.get(model, MOI.ResultCount()) == 1
     @test round.(Int, MOI.get.(model, MOI.VariablePrimal(1), x)) == expected_state
     @test MOI.get(model, MOI.ObjectiveValue(1)) ≈ expected_value
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
+
+    return nothing
+end
+
+function _test_mip_sampler_exact_parity()
+    @testset "GLPK parity with ExactSampler" begin
+        for case in MIP_PARITY_CASES
+            @testset "$(case.name)" begin
+                mip_model, mip_x = _build_mip_parity_model(MIPSampler.Optimizer, case)
+                exact_model, _ = _build_mip_parity_model(ExactSampler.Optimizer, case)
+
+                MOI.optimize!(mip_model)
+                MOI.optimize!(exact_model)
+
+                mip_state = round.(Int, MOI.get.(mip_model, MOI.VariablePrimal(1), mip_x))
+                mip_value = MOI.get(mip_model, MOI.ObjectiveValue(1))
+
+                @test MOI.get(mip_model, MOI.TerminationStatus()) == MOI.OPTIMAL
+                @test mip_state == case.expected_state
+                @test mip_value ≈ case.expected_value
+                @test mip_value ≈ _best_exact_value(exact_model)
+            end
+        end
+    end
 
     return nothing
 end
@@ -162,6 +307,7 @@ function test_mip_sampler()
         _test_mip_sampler_quadratic_only()
         _test_mip_sampler_mixed_quadratic_signs()
         _test_mip_sampler_attribute_forwarding()
+        _test_mip_sampler_exact_parity()
     end
 
     return nothing

--- a/test/drivers/mip_sampler.jl
+++ b/test/drivers/mip_sampler.jl
@@ -1,0 +1,149 @@
+using GLPK
+
+const MIP_SAF{T} = MOI.ScalarAffineFunction{T}
+const MIP_SAT{T} = MOI.ScalarAffineTerm{T}
+const MIP_SQF{T} = MOI.ScalarQuadraticFunction{T}
+const MIP_SQT{T} = MOI.ScalarQuadraticTerm{T}
+
+const MIP_TEST_OPTIMIZER = MOI.OptimizerWithAttributes(GLPK.Optimizer, MOI.Silent() => true)
+
+function _config_mip_sampler!(model)
+    MOI.set(model, MIPSampler.MIPOptimizer(), MIP_TEST_OPTIMIZER)
+
+    return nothing
+end
+
+function _build_mip_test_model(::Type{T}, n::Integer) where {T}
+    model = MOI.instantiate(MIPSampler.Optimizer; with_bridge_type = T)
+
+    MOI.set(model, MIPSampler.MIPOptimizer(), MIP_TEST_OPTIMIZER)
+
+    x, _ = MOI.add_constrained_variables(model, fill(MOI.ZeroOne(), n))
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+
+    return model, x
+end
+
+function _assert_single_solution(model, x, expected_state, expected_value)
+    @test MOI.get(model, MOI.ResultCount()) == 1
+    @test round.(Int, MOI.get.(model, MOI.VariablePrimal(1), x)) == expected_state
+    @test MOI.get(model, MOI.ObjectiveValue(1)) ≈ expected_value
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
+
+    return nothing
+end
+
+function _test_mip_sampler_missing_optimizer()
+    @testset "Missing MIP optimizer" begin
+        model = MOI.instantiate(MIPSampler.Optimizer; with_bridge_type = Float64)
+        x, _ = MOI.add_constrained_variables(model, fill(MOI.ZeroOne(), 1))
+
+        MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+        MOI.set(model, MOI.ObjectiveFunction{VI}(), x[1])
+
+        @test_throws ArgumentError MOI.optimize!(model)
+    end
+
+    return nothing
+end
+
+function _test_mip_sampler_linear_only()
+    @testset "Linear only" begin
+        model, x = _build_mip_test_model(Float64, 3)
+        f = MIP_SAF{Float64}(
+            MIP_SAT{Float64}[
+                MIP_SAT{Float64}(2.0, x[1]),
+                MIP_SAT{Float64}(-3.0, x[2]),
+                MIP_SAT{Float64}(1.0, x[3]),
+            ],
+            0.0,
+        )
+
+        MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+        MOI.optimize!(model)
+
+        _assert_single_solution(model, x, [0, 1, 0], -3.0)
+    end
+
+    return nothing
+end
+
+function _test_mip_sampler_quadratic_only()
+    @testset "Quadratic only" begin
+        model, x = _build_mip_test_model(Float64, 2)
+        f = MIP_SQF{Float64}(
+            MIP_SQT{Float64}[MIP_SQT{Float64}(-3.0, x[1], x[2])],
+            MIP_SAT{Float64}[],
+            0.0,
+        )
+
+        MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+        MOI.optimize!(model)
+
+        _assert_single_solution(model, x, [1, 1], -3.0)
+    end
+
+    return nothing
+end
+
+function _test_mip_sampler_mixed_quadratic_signs()
+    @testset "Mixed quadratic signs" begin
+        model, x = _build_mip_test_model(Float64, 3)
+        f = MIP_SQF{Float64}(
+            MIP_SQT{Float64}[
+                MIP_SQT{Float64}(-2.0, x[1], x[3]),
+                MIP_SQT{Float64}(3.0, x[2], x[3]),
+                MIP_SQT{Float64}(-1.0, x[1], x[2]),
+            ],
+            MIP_SAT{Float64}[
+                MIP_SAT{Float64}(1.0, x[1]),
+                MIP_SAT{Float64}(1.0, x[2]),
+            ],
+            0.0,
+        )
+
+        MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+        MOI.optimize!(model)
+
+        _assert_single_solution(model, x, [1, 0, 1], -1.0)
+    end
+
+    return nothing
+end
+
+function _test_mip_sampler_attribute_forwarding()
+    @testset "Attribute forwarding" begin
+        model, x = _build_mip_test_model(Float64, 1)
+
+        MOI.set(model, MOI.TimeLimitSec(), 10.0)
+        MOI.set(model, MOI.NumberOfThreads(), 1)
+        MOI.set(model, MOI.Silent(), true)
+        MOI.set(model, MOI.ObjectiveFunction{VI}(), x[1])
+
+        MOI.optimize!(model)
+
+        raw = MOI.get(model, MOI.RawSolver())
+        metadata = QUBOTools.metadata(QUBOTools.solution(raw))
+        forwarded = metadata["attributes"]["forwarded"]
+
+        @test "MOI.TimeLimitSec" in forwarded
+        @test "MOI.Silent" in forwarded
+    end
+
+    return nothing
+end
+
+function test_mip_sampler()
+    QUBODrivers.test(_config_mip_sampler!, MIPSampler.Optimizer)
+
+    @testset "□ MIPSampler" verbose = true begin
+        _test_mip_sampler_missing_optimizer()
+        _test_mip_sampler_linear_only()
+        _test_mip_sampler_quadratic_only()
+        _test_mip_sampler_mixed_quadratic_signs()
+        _test_mip_sampler_attribute_forwarding()
+    end
+
+    return nothing
+end

--- a/test/drivers/sampler_bundle.jl
+++ b/test/drivers/sampler_bundle.jl
@@ -1,5 +1,6 @@
 include("exact_sampler.jl")
 include("identity_sampler.jl")
+include("mip_sampler.jl")
 include("random_sampler.jl")
 include("benchmark.jl")
 
@@ -7,6 +8,7 @@ function test_sampler_bundle()
     @testset "□ Utility Samplers Bundle" verbose = true begin
         test_exact_sampler()
         test_identiy_sampler()
+        test_mip_sampler()
         test_random_sampler()
         test_benchmark_helper()
     end


### PR DESCRIPTION
## Summary

- Add `MIPSampler.Optimizer`, a MOI-native utility sampler that linearizes QUBO terms into a binary MIP and solves it with a user-supplied MOI optimizer factory.
- Add `MIPSampler.MIPOptimizer()` for the backend factory, including support for `MOI.OptimizerWithAttributes`.
- Add GLPK-backed sampler tests, direct known-optimum cases, missing-backend coverage, attribute-forwarding smoke tests, and sampler/docs listings.

## Tests run

- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`
  - Result: passed, 729/729 tests.
- `julia --project=/tmp/qubodrivers-test-1.10 -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.test("QUBODrivers")'`
  - Result: passed, 729/729 tests.
- `julia +1.12 --project=docs/ -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate(); include("docs/make.jl")'`
  - Result: passed. Local Documenter deployment auto-detection warning only.
- `git diff --cached --check`
  - Result: passed.

## Notes

- The Julia 1.10 test was run from a temporary environment to avoid an ignored local `Manifest.toml` in the checkout that was resolved with Julia 1.12.
- No separate formatter command is documented in the repository CI or README.

Closes #26
