### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## v0.5.0 - 2026-05-27
+
+- Add `MIPSampler.Optimizer`, an MOI-native exact MIP-backed baseline sampler
+  using a user-supplied MOI optimizer.
+- Document MIP sampler usage and the binary-product linearization reference.
+- Add GLPK-backed MIPSampler parity tests against `ExactSampler`.
+
 ## v0.4.0 - 2026-05-22
 
 - Raise the minimum supported Julia version to 1.10.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBODrivers"
 uuid = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "AndradeTiago <tiago.andrade@psr-inc.com>", "joaquimg <joaquim@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"


### PR DESCRIPTION
## Summary

Prepare QUBODrivers.jl v0.5.0 for release.

- Bump `Project.toml` from `0.4.0` to `0.5.0`.
- Add changelog notes for the new MIPSampler release.

## Why v0.5.0

This release adds the public `MIPSampler.Optimizer` sampler, so a minor version bump is appropriate.

## Tests run

- `git diff --check`: passed
- `python -m unittest discover -s .github/tests -p "test_*.py"`: passed, 8/8
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`: passed, 765/765
- `julia +1.12 --project=docs docs/make.jl`: passed; deployment skipped outside CI

## Release steps after merge

- Create tag and GitHub release `v0.5.0` from the merged release commit.
