### PR TITLE
[codex] Modernize GitHub Actions workflows

### DIFF
--- a/.github/tests/test_julia_ci_policy.py
+++ b/.github/tests/test_julia_ci_policy.py
@@ -15,6 +15,7 @@ DEPRECATED_WORKFLOW_REFERENCES = (
     "actions/setup-python@v5",
     "julia-actions/setup-julia@v1",
     "julia-actions/setup-julia@latest",
+    "actions/labeler@v5",
     "codecov/codecov-action@v5",
     "windows-latest",
 )

--- a/.github/tests/test_julia_ci_policy.py
+++ b/.github/tests/test_julia_ci_policy.py
@@ -9,6 +9,15 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 MINIMUM_JULIA_VERSION = "1.10"
 LATEST_STABLE_JULIA_VERSION = "1"
 QUBOTOOLS_COMPAT_VERSION = "0.12"
+SUPPORTED_CI_RUNNERS = {"ubuntu-latest", "windows-2025-vs2026"}
+DEPRECATED_WORKFLOW_REFERENCES = (
+    "actions/checkout@v4",
+    "actions/setup-python@v5",
+    "julia-actions/setup-julia@v1",
+    "julia-actions/setup-julia@latest",
+    "codecov/codecov-action@v5",
+    "windows-latest",
+)
 
 
 class JuliaCiPolicyTests(unittest.TestCase):
@@ -44,6 +53,12 @@ class JuliaCiPolicyTests(unittest.TestCase):
 
         self.assertEqual(versions, {MINIMUM_JULIA_VERSION, LATEST_STABLE_JULIA_VERSION})
 
+    def test_ci_matrix_uses_explicit_supported_runners(self) -> None:
+        workflow = self.load_yaml(".github/workflows/ci.yml")
+        matrix = workflow["jobs"]["test"]["strategy"]["matrix"]
+
+        self.assertEqual(set(matrix["os"]), SUPPORTED_CI_RUNNERS)
+
     def test_documentation_build_uses_latest_stable_julia(self) -> None:
         workflow = self.load_yaml(".github/workflows/documentation.yml")
         steps = workflow["jobs"]["build"]["steps"]
@@ -58,6 +73,15 @@ class JuliaCiPolicyTests(unittest.TestCase):
             setup_steps[0]["with"]["version"],
             LATEST_STABLE_JULIA_VERSION,
         )
+
+    def test_workflows_do_not_use_deprecated_action_or_runner_references(self) -> None:
+        workflow_text = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in sorted((ROOT / ".github" / "workflows").glob("*.yml"))
+        )
+
+        for reference in DEPRECATED_WORKFLOW_REFERENCES:
+            self.assertNotIn(reference, workflow_text)
 
 
 if __name__ == "__main__":

--- a/.github/tests/test_label_automation.py
+++ b/.github/tests/test_label_automation.py
@@ -83,6 +83,32 @@ class LabelAutomationContractTests(unittest.TestCase):
             header,
         )
 
+    def test_pr_labeler_uses_node24_labeler_action(self) -> None:
+        workflow = self.load_yaml(".github/workflows/pr-labeler.yml")
+        steps = workflow["jobs"]["label"]["steps"]
+
+        self.assertIn("actions/labeler@v6", [step.get("uses") for step in steps])
+
+    def test_shared_label_maintenance_uses_node24_checkout(self) -> None:
+        for workflow_path, job_name in (
+            (".github/workflows/label-sync.yml", "sync"),
+            (".github/workflows/label-backfill.yml", "backfill"),
+        ):
+            workflow = self.load_yaml(workflow_path)
+            steps = workflow["jobs"][job_name]["steps"]
+            checkout_steps = [
+                step
+                for step in steps
+                if step.get("uses") == "actions/checkout@v6"
+                and step.get("with", {}).get("repository") == "JuliaQUBO/.github"
+            ]
+
+            self.assertEqual(
+                len(checkout_steps),
+                1,
+                f"{workflow_path} should check out shared label automation with checkout@v6",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
     name: Workflow tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install workflow test dependencies
         run: python -m pip install pyyaml
       - name: Lint GitHub Actions workflows
-        uses: devops-actions/actionlint@e7ee33fbf5aa8c9f9ee1145137f3e52e25d6a35b # v0.1.3
+        uses: devops-actions/actionlint@9fb9c192862f19e684586ca84b500461bcd8a541 # v0.1.12
       - name: Run workflow regression tests
         run: |
           bash .github/tests/doc_preview_cleanup.sh
@@ -34,12 +34,12 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-          - windows-latest
+          - windows-2025-vs2026
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -48,7 +48,7 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - name: Upload coverage to Codecov
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/doccleanup.yml
+++ b/.github/workflows/doccleanup.yml
@@ -11,13 +11,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           path: repo
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: gh-pages

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Julia
-        uses: julia-actions/setup-julia@latest
+        uses: julia-actions/setup-julia@v3
         with:
           version: '1'
       - name: Develop QUBODrivers.jl

--- a/.github/workflows/label-backfill.yml
+++ b/.github/workflows/label-backfill.yml
@@ -21,7 +21,22 @@ permissions:
 
 jobs:
   backfill:
-    uses: JuliaQUBO/.github/.github/workflows/backfill-labels.yml@02781d5b27dd8f0d2bc5b1fe3845eff7113244ec
-    with:
-      dry_run: ${{ inputs.dry_run }}
-      max_items: ${{ inputs.max_items }}
+    runs-on: ubuntu-latest
+    env:
+      SHARED_AUTOMATION_REF: 02781d5b27dd8f0d2bc5b1fe3845eff7113244ec
+    steps:
+      - name: Checkout shared automation repository
+        uses: actions/checkout@v6
+        with:
+          repository: JuliaQUBO/.github
+          ref: ${{ env.SHARED_AUTOMATION_REF }}
+          path: shared
+
+      - name: Backfill labels
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          MAX_ITEMS: ${{ inputs.max_items }}
+        run: bash shared/.github/scripts/backfill-labels.sh

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -17,6 +17,22 @@ permissions:
 
 jobs:
   sync:
-    uses: JuliaQUBO/.github/.github/workflows/sync-labels.yml@02781d5b27dd8f0d2bc5b1fe3845eff7113244ec
-    with:
-      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+    runs-on: ubuntu-latest
+    env:
+      SHARED_AUTOMATION_REF: 02781d5b27dd8f0d2bc5b1fe3845eff7113244ec
+    steps:
+      - name: Checkout shared automation repository
+        uses: actions/checkout@v6
+        with:
+          repository: JuliaQUBO/.github
+          ref: ${{ env.SHARED_AUTOMATION_REF }}
+          path: shared
+
+      - name: Sync labels
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+          LABELS_FILE: shared/.github/labels/shared-labels.json
+        run: bash shared/.github/scripts/sync-labels.sh

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -14,6 +14,11 @@ permissions:
 
 jobs:
   label:
-    uses: JuliaQUBO/.github/.github/workflows/pr-labeler.yml@02781d5b27dd8f0d2bc5b1fe3845eff7113244ec
-    with:
-      configuration_path: .github/labeler.yml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply path-based PR labels
+        uses: actions/labeler@v6
+        with:
+          repo-token: ${{ github.token }}
+          sync-labels: false
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/validate-label-automation.yml
+++ b/.github/workflows/validate-label-automation.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.x"
 


### PR DESCRIPTION
## Summary

- Update GitHub-hosted JavaScript actions to Node 24-ready major versions:
  - `actions/checkout@v6`
  - `actions/setup-python@v6`
  - `julia-actions/setup-julia@v3`
  - `codecov/codecov-action@v6`
- Move the Windows CI matrix from `windows-latest` to the explicit `windows-2025-vs2026` runner label.
- Update the actionlint wrapper used by CI to its latest pinned release.
- Replace the label PR workflow's reusable `actions/labeler@v5` path with direct `actions/labeler@v6`, and run shared label sync/backfill scripts through `actions/checkout@v6`.
- Add workflow regression tests that reject deprecated action/runtime references and keep the explicit runner matrix policy in place.

## Tests run

- `git diff --check` - passed
- `bash .github/tests/doc_preview_cleanup.sh` - passed
- `python -m unittest discover -s .github/tests -p "test_*.py"` - passed, 12 tests
- `docker run --rm -v /home/bernalde/repos/QUBODrivers.jl:/repo --workdir /repo rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color` - passed

## Notes

- Julia package tests were not run locally because this PR only changes GitHub Actions workflow configuration and workflow regression tests.
