### PR TITLE
Add Dependabot dependency maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "julia"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    groups:
+      docs-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "julia"
+    directory: "/test"
+    schedule:
+      interval: "weekly"
+    groups:
+      test-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/tests/test_julia_ci_policy.py
+++ b/.github/tests/test_julia_ci_policy.py
@@ -75,6 +75,51 @@ class JuliaCiPolicyTests(unittest.TestCase):
             LATEST_STABLE_JULIA_VERSION,
         )
 
+    def test_dependabot_tracks_julia_compat_environments(self) -> None:
+        dependabot = self.load_yaml(".github/dependabot.yml")
+        expected_groups_by_directory = {
+            "/": "root-julia-dependencies",
+            "/docs": "docs-julia-dependencies",
+            "/test": "test-julia-dependencies",
+        }
+
+        julia_updates = {
+            update["directory"]: update
+            for update in dependabot["updates"]
+            if update["package-ecosystem"] == "julia"
+        }
+
+        self.assertEqual(
+            set(julia_updates),
+            set(expected_groups_by_directory),
+        )
+
+        for directory, group_name in expected_groups_by_directory.items():
+            project_path = (
+                "Project.toml"
+                if directory == "/"
+                else f"{directory.removeprefix('/')}/Project.toml"
+            )
+
+            self.assertIn("compat", self.load_toml(project_path))
+            self.assertEqual(julia_updates[directory]["schedule"]["interval"], "weekly")
+            self.assertEqual(
+                julia_updates[directory]["groups"][group_name]["patterns"],
+                ["*"],
+            )
+
+    def test_dependabot_tracks_github_actions_monthly(self) -> None:
+        dependabot = self.load_yaml(".github/dependabot.yml")
+        github_actions_updates = [
+            update
+            for update in dependabot["updates"]
+            if update["package-ecosystem"] == "github-actions"
+        ]
+
+        self.assertEqual(len(github_actions_updates), 1)
+        self.assertEqual(github_actions_updates[0]["directory"], "/")
+        self.assertEqual(github_actions_updates[0]["schedule"]["interval"], "monthly")
+
     def test_workflows_do_not_use_deprecated_action_or_runner_references(self) -> None:
         workflow_text = "\n".join(
             path.read_text(encoding="utf-8")


### PR DESCRIPTION
Summary:
- Add the standard Dependabot configuration for QUBODrivers.jl.
- Track Julia compatibility updates for `/`, `/docs`, and `/test`, because each environment has its own `[compat]` bounds.
- Track GitHub Actions updates monthly.
- Add workflow-policy tests for the Dependabot Julia and GitHub Actions entries.

Permissions and secrets:
- This repository uses the public Julia General registry for these environments, so Dependabot does not need a PAT or custom repository secret.
- The default Dependabot/GitHub token behavior is sufficient for opening dependency update pull requests. Normal CI should validate those pull requests before merge.
- No CompatHelper workflow is added.

Tests:
- `bash .github/tests/doc_preview_cleanup.sh` - passed
- `python -m unittest discover -s .github/tests -p "test_*.py"` - passed, 14 tests

Notes:
- Julia package tests were not run locally because this is a GitHub dependency-maintenance configuration change with focused workflow-policy coverage.

Closes #34
