### PR TITLE
Skip docs deploy for Dependabot PRs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,7 +21,11 @@ jobs:
         uses: julia-actions/julia-buildpkg@latest
         with: 
             project: "docs/"
+      - name: Build docs
+        if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+        run: julia --project=docs/ docs/make.jl --skip-deploy
       - name: Build and deploy
+        if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
         run: julia --project=docs/ docs/make.jl


### PR DESCRIPTION
Dependabot PR documentation builds currently complete successfully and then fail when Documenter tries to push a preview to `gh-pages` using the restricted `github-actions[bot]` token.

This keeps docs builds running for Dependabot PRs but passes `--skip-deploy` so the preview push is skipped. Normal pushes and non-Dependabot PRs still use the existing deploy path.

Verification:
- `git diff --check`
- `julia --project=docs/ -e 'using Pkg; Pkg.develop(path=pwd())'`
- `julia --project=docs/ docs/make.jl --skip-deploy`