### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## v0.5.1 - 2026-06-03
+
+- Add Dependabot dependency maintenance for Julia environments and GitHub
+  Actions workflows.
+- Skip documentation preview deployment for Dependabot pull requests so docs
+  builds can still validate dependency updates without requiring write access
+  to `gh-pages`.
+- Add `TOML` compatibility bounds for the root package environment and build
+  documentation against QUBODrivers 0.5.
+
 ## v0.5.0 - 2026-05-27
 
 - Add `MIPSampler.Optimizer`, an MOI-native exact MIP-backed baseline sampler

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBODrivers"
 uuid = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "AndradeTiago <tiago.andrade@psr-inc.com>", "joaquimg <joaquim@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"


### PR DESCRIPTION
## Summary

Prepare QUBODrivers.jl v0.5.1 for release.

- Bump `Project.toml` from `0.5.0` to `0.5.1`.
- Add changelog notes for the dependency-maintenance and docs-CI rollout.

## Why v0.5.1

This is a patch release for maintenance changes after v0.5.0:

- Dependabot maintenance was enabled for Julia environments and GitHub Actions.
- Dependabot-safe documentation builds were added by skipping preview deploys for Dependabot pull requests.
- Root `TOML` compatibility bounds and docs environment compatibility were updated.

## Tests run

- `git diff --check`: passed
- `python -m unittest discover -s .github/tests -p "test_*.py"`: passed, 14/14
- `bash .github/tests/doc_preview_cleanup.sh`: passed
- `actionlint`: passed
- `julia --project=. -e 'using Pkg; Pkg.test()'`: passed, 765/765
- `julia --project=docs/ -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'`: passed
- `julia --project=docs/ docs/make.jl --skip-deploy`: passed

## Release steps after merge

- Create tag and GitHub release `v0.5.1` from the merged release commit.
