### PR TITLE
Add post-sampling callback interface

### DIFF
--- a/docs/src/booklet/3-attributes.md
+++ b/docs/src/booklet/3-attributes.md
@@ -43,6 +43,8 @@ and the sampler context after raw sampling. Metadata-only annotations are
 allowed by default. To emit changed sample states, values, reads, sense, or
 domain, set `QUBODrivers.PostSampleTransform()` or raw
 `"post_sample_transform"` to `true` and return the transformed `SampleSet`.
+Replacement `SampleSet`s should carry over or intentionally rebuild raw
+backend metadata.
 Objective annotations should follow QUBOTools' `"objectives"` metadata
 convention, and reformulation-specific projection or repair data should come
 from ToQUBO/QUBOTools metadata rather than from QUBODrivers.

--- a/docs/src/booklet/3-attributes.md
+++ b/docs/src/booklet/3-attributes.md
@@ -43,6 +43,9 @@ and the sampler context after raw sampling. Metadata-only annotations are
 allowed by default. To emit changed sample states, values, reads, sense, or
 domain, set `QUBODrivers.PostSampleTransform()` or raw
 `"post_sample_transform"` to `true` and return the transformed `SampleSet`.
+Objective annotations should follow QUBOTools' `"objectives"` metadata
+convention, and reformulation-specific projection or repair data should come
+from ToQUBO/QUBOTools metadata rather than from QUBODrivers.
 
 ## An advanced example
 

--- a/docs/src/booklet/3-attributes.md
+++ b/docs/src/booklet/3-attributes.md
@@ -6,6 +6,10 @@
 QUBODrivers.SamplerAttribute
 QUBODrivers.FinalNumberOfReads
 QUBODrivers.final_number_of_reads
+QUBODrivers.PostSampleCallback
+QUBODrivers.PostSampleTransform
+QUBODrivers.post_sample_callback
+QUBODrivers.post_sample_transform
 ```
 
 ```@docs
@@ -32,6 +36,13 @@ that attribute.
 
 Built-in samplers that do not have a separate final sampling phase document the
 attribute as ignored and report their fixed returned read count in metadata.
+
+Generated optimizers also support `QUBODrivers.PostSampleCallback()` and the
+raw key `"post_sample_callback"`. The callback receives a copied `SampleSet`
+and the sampler context after raw sampling. Metadata-only annotations are
+allowed by default. To emit changed sample states, values, reads, sense, or
+domain, set `QUBODrivers.PostSampleTransform()` or raw
+`"post_sample_transform"` to `true` and return the transformed `SampleSet`.
 
 ## An advanced example
 

--- a/docs/src/manual/4-setup.md
+++ b/docs/src/manual/4-setup.md
@@ -105,18 +105,21 @@ The callback receives a copy of the raw backend `SampleSet` and the sampler
 context. Metadata-only annotations are allowed by default. If the callback
 changes sample states, objective values, reads, sense, or domain, also set
 `QUBODrivers.PostSampleTransform()` or raw `"post_sample_transform"` to `true`
-and return the transformed `SampleSet`. When transformed samples are emitted,
-QUBODrivers records postprocess metadata and preserves the raw sample frame and
-records in the emitted solution metadata.
+and return the transformed `SampleSet`. Replacement `SampleSet`s should carry
+over or intentionally rebuild the original metadata; otherwise backend origin,
+status, reads, timing, and diagnostics metadata from the raw output are lost.
+When transformed samples are emitted, QUBODrivers records postprocess metadata
+and preserves the raw sample frame and records in the emitted solution metadata.
 
 Use this hook for driver-level sample annotation, objective bookkeeping, or
 controlled repair of emitted samples. For objective bookkeeping, prefer the
-QUBOTools convention `metadata(sampleset)["objectives"][label]`; recent
-QUBOTools versions provide `QUBOTools.annotate_objectives!` and
-`QUBOTools.verify_objective_values` helpers for this. Problem-specific repair
-algorithms and the reformulation metadata needed to implement them should live
-outside QUBODrivers. ToQUBO records reformulation metadata under
-`metadata(QUBOTools.backend(model))["toqubo"]["reformulation"]` and exposes
+QUBOTools convention `metadata(sampleset)["objectives"][label]`. If your
+QUBOTools version includes objective-bookkeeping helpers, prefer
+`QUBOTools.annotate_objectives!` and `QUBOTools.verify_objective_values` for
+this. Problem-specific repair algorithms and the reformulation metadata needed
+to implement them should live outside QUBODrivers. ToQUBO versions that expose
+reformulation metadata record it under
+`metadata(QUBOTools.backend(model))["toqubo"]["reformulation"]` and expose
 helpers such as `ToQUBO.project_original_state`; QUBODrivers only provides the
 sampler-interface hook.
 

--- a/docs/src/manual/4-setup.md
+++ b/docs/src/manual/4-setup.md
@@ -106,13 +106,19 @@ context. Metadata-only annotations are allowed by default. If the callback
 changes sample states, objective values, reads, sense, or domain, also set
 `QUBODrivers.PostSampleTransform()` or raw `"post_sample_transform"` to `true`
 and return the transformed `SampleSet`. When transformed samples are emitted,
-QUBODrivers records postprocess metadata and preserves the raw sample records in
-the emitted solution metadata.
+QUBODrivers records postprocess metadata and preserves the raw sample frame and
+records in the emitted solution metadata.
 
 Use this hook for driver-level sample annotation, objective bookkeeping, or
-controlled repair of emitted samples. Problem-specific repair algorithms and the
-reformulation metadata needed to implement them should live in QUBOTools or
-ToQUBO; QUBODrivers only provides the sampler-interface hook.
+controlled repair of emitted samples. For objective bookkeeping, prefer the
+QUBOTools convention `metadata(sampleset)["objectives"][label]`; recent
+QUBOTools versions provide `QUBOTools.annotate_objectives!` and
+`QUBOTools.verify_objective_values` helpers for this. Problem-specific repair
+algorithms and the reformulation metadata needed to implement them should live
+outside QUBODrivers. ToQUBO records reformulation metadata under
+`metadata(QUBOTools.backend(model))["toqubo"]["reformulation"]` and exposes
+helpers such as `ToQUBO.project_original_state`; QUBODrivers only provides the
+sampler-interface hook.
 
 ## The [`QUBODrivers.sample`](@ref) method
 
@@ -162,8 +168,9 @@ QUBODrivers recommends these top-level metadata keys for driver attributes:
 - `"status"` and `"termination_status"`: raw and structured termination status.
 
 When a post-sampling callback runs, QUBODrivers records callback metadata under
-`"postprocess" => "callback"`. If the callback transforms emitted samples, raw
-sample records are stored under `"postprocess" => "raw_samples"`.
+`"postprocess" => "callback"`. If the callback transforms emitted samples, the
+raw sample frame and records are stored under
+`"postprocess" => "raw_samples"`.
 
 ## A complete example
 

--- a/docs/src/manual/4-setup.md
+++ b/docs/src/manual/4-setup.md
@@ -85,6 +85,35 @@ evaluations. `"final_num_reads"` controls the reads used to build the returned
 `QUBODrivers.final_number_of_reads(sampler)` to get the effective value; it
 defaults to `"num_reads"` when that attribute is supported.
 
+Generated optimizers also support a generic post-sampling hook through
+`QUBODrivers.PostSampleCallback()` and the raw key
+`"post_sample_callback"`. The callback is called after
+[`QUBODrivers.sample`](@ref) returns and before the final `SampleSet` is
+attached:
+
+```julia
+callback = function (sampleset, sampler)
+    QUBOTools.metadata(sampleset)["postprocess_note"] = "annotated"
+
+    return nothing
+end
+
+MOI.set(sampler, QUBODrivers.PostSampleCallback(), callback)
+```
+
+The callback receives a copy of the raw backend `SampleSet` and the sampler
+context. Metadata-only annotations are allowed by default. If the callback
+changes sample states, objective values, reads, sense, or domain, also set
+`QUBODrivers.PostSampleTransform()` or raw `"post_sample_transform"` to `true`
+and return the transformed `SampleSet`. When transformed samples are emitted,
+QUBODrivers records postprocess metadata and preserves the raw sample records in
+the emitted solution metadata.
+
+Use this hook for driver-level sample annotation, objective bookkeeping, or
+controlled repair of emitted samples. Problem-specific repair algorithms and the
+reformulation metadata needed to implement them should live in QUBOTools or
+ToQUBO; QUBODrivers only provides the sampler-interface hook.
+
 ## The [`QUBODrivers.sample`](@ref) method
 
 ```@docs
@@ -131,6 +160,10 @@ QUBODrivers recommends these top-level metadata keys for driver attributes:
   internal phase, both values may be the same;
 - `"seeds"`: dictionary of sampler, model, optimizer, or backend seeds;
 - `"status"` and `"termination_status"`: raw and structured termination status.
+
+When a post-sampling callback runs, QUBODrivers records callback metadata under
+`"postprocess" => "callback"`. If the callback transforms emitted samples, raw
+sample records are stored under `"postprocess" => "raw_samples"`.
 
 ## A complete example
 

--- a/docs/src/manual/7-integration.md
+++ b/docs/src/manual/7-integration.md
@@ -122,6 +122,9 @@ When adapting the example for a real sampler:
 - include useful metadata such as timing, backend status, and backend version;
 - leave generic post-sampling annotation or repair to
   `QUBODrivers.PostSampleCallback()` when users need a configurable hook;
+- use QUBOTools objective metadata and ToQUBO reformulation metadata for
+  objective bookkeeping, original-variable projection, and encoding-specific
+  auxiliary handling;
 - run `QUBODrivers.test(YourSampler.Optimizer)` in the package test suite.
 
 The built-in `RandomSampler` and `ExactSampler` implementations are compact

--- a/docs/src/manual/7-integration.md
+++ b/docs/src/manual/7-integration.md
@@ -120,6 +120,8 @@ When adapting the example for a real sampler:
 - convert backend outputs into `Sample{T,Int}` entries;
 - return a `SampleSet{T}` with the correct `sense` and `domain`;
 - include useful metadata such as timing, backend status, and backend version;
+- leave generic post-sampling annotation or repair to
+  `QUBODrivers.PostSampleCallback()` when users need a configurable hook;
 - run `QUBODrivers.test(YourSampler.Optimizer)` in the package test suite.
 
 The built-in `RandomSampler` and `ExactSampler` implementations are compact

--- a/docs/src/manual/8-api.md
+++ b/docs/src/manual/8-api.md
@@ -25,6 +25,10 @@ QUBODrivers.@setup
 QUBODrivers.SamplerAttribute
 QUBODrivers.FinalNumberOfReads
 QUBODrivers.final_number_of_reads
+QUBODrivers.PostSampleCallback
+QUBODrivers.PostSampleTransform
+QUBODrivers.post_sample_callback
+QUBODrivers.post_sample_transform
 QUBODrivers.RawSamplerAttribute
 QUBODrivers.@raw_attr_str
 QUBODrivers.get_raw_attr

--- a/src/QUBODrivers.jl
+++ b/src/QUBODrivers.jl
@@ -49,6 +49,7 @@ include("library/setup/quote.jl")
 include("library/setup/macro.jl")
 
 export AbstractSampler, FinalNumberOfReads, final_number_of_reads
+export PostSampleCallback, PostSampleTransform, post_sample_callback, post_sample_transform
 export ExactSampler, IdentitySampler, MIPSampler, RandomSampler
 
 include("library/drivers/ExactSampler.jl")

--- a/src/interface/attributes.jl
+++ b/src/interface/attributes.jl
@@ -27,9 +27,13 @@ RawSamplerAttribute(key::String) = RawSamplerAttribute{Symbol(key)}()
 
 const _NUMBER_OF_READS_RAW       = "num_reads"
 const _FINAL_NUMBER_OF_READS_RAW = "final_num_reads"
+const _POST_SAMPLE_CALLBACK_RAW  = "post_sample_callback"
+const _POST_SAMPLE_TRANSFORM_RAW = "post_sample_transform"
 
-const _RawNumberOfReads      = RawSamplerAttribute{Symbol(_NUMBER_OF_READS_RAW)}
-const _RawFinalNumberOfReads = RawSamplerAttribute{Symbol(_FINAL_NUMBER_OF_READS_RAW)}
+const _RawNumberOfReads       = RawSamplerAttribute{Symbol(_NUMBER_OF_READS_RAW)}
+const _RawFinalNumberOfReads  = RawSamplerAttribute{Symbol(_FINAL_NUMBER_OF_READS_RAW)}
+const _RawPostSampleCallback  = RawSamplerAttribute{Symbol(_POST_SAMPLE_CALLBACK_RAW)}
+const _RawPostSampleTransform = RawSamplerAttribute{Symbol(_POST_SAMPLE_TRANSFORM_RAW)}
 
 @doc raw"""
     FinalNumberOfReads()
@@ -47,6 +51,35 @@ Generated optimizers created by [`QUBODrivers.@setup`](@ref) support this
 attribute and the raw `"final_num_reads"` key.
 """
 struct FinalNumberOfReads <: SamplerAttribute end
+
+@doc raw"""
+    PostSampleCallback()
+
+Generic sampler optimizer attribute for a callback applied after backend
+sampling and before the final `SampleSet` is attached to the optimizer.
+
+The raw optimizer attribute key is `"post_sample_callback"`. The callback is
+called as `callback(sampleset, sampler)`, where `sampleset` is a copy of the raw
+backend output and `sampler` is the optimizer/model context. The callback may
+mutate the copied sample-set metadata and return `nothing`, or return a
+`SampleSet` to replace the emitted samples. Replacing or changing sample
+states, values, reads, sense, or domain requires [`PostSampleTransform`](@ref)
+to be set to `true`.
+"""
+struct PostSampleCallback <: SamplerAttribute end
+
+@doc raw"""
+    PostSampleTransform()
+
+Generic sampler optimizer attribute controlling whether
+[`PostSampleCallback`](@ref) may transform emitted samples.
+
+The raw optimizer attribute key is `"post_sample_transform"`, and the default
+value is `false`. When set to `true`, a post-sample callback may return a
+replacement `SampleSet`. QUBODrivers records callback metadata and preserves the
+raw samples in the emitted solution metadata.
+"""
+struct PostSampleTransform <: SamplerAttribute end
 
 @doc raw"""
     @raw_attr_str("key")
@@ -124,6 +157,42 @@ function final_number_of_reads(sampler::AbstractSampler)
     end
 end
 
+@doc raw"""
+    post_sample_callback(sampler)
+
+Return the configured post-sample callback for `sampler`, or `nothing` when no
+callback is configured or the sampler does not support the generic callback
+attribute.
+"""
+function post_sample_callback(sampler::AbstractSampler)
+    attr = _RawPostSampleCallback()
+
+    try
+        return MOI.get(sampler, attr)
+    catch err
+        _is_unavailable_raw_attr(err, attr) ? nothing : rethrow()
+    end
+end
+
+@doc raw"""
+    post_sample_transform(sampler)::Bool
+
+Return whether the configured post-sample callback may transform emitted sample
+states, values, reads, sense, or domain. Samplers that do not support the
+generic transform attribute default to `false`.
+"""
+function post_sample_transform(sampler::AbstractSampler)::Bool
+    attr = _RawPostSampleTransform()
+
+    transform = try
+        MOI.get(sampler, attr)
+    catch err
+        _is_unavailable_raw_attr(err, attr) ? false : rethrow()
+    end
+
+    return transform::Bool
+end
+
 function _is_unavailable_raw_attr(err, attr::RawSamplerAttribute)
     return err isa MOI.GetAttributeNotAllowed{typeof(attr)}
 end
@@ -151,5 +220,15 @@ function _validate_final_number_of_reads(value)
     return nothing
 end
 
+function _validate_post_sample_transform(value)
+    value isa Bool || error("Value for 'PostSampleTransform' must be a boolean")
+
+    return nothing
+end
+
 MOIU.map_indices(_, ::FinalNumberOfReads, value) = value
 MOIU.map_indices(_, ::_RawFinalNumberOfReads, value) = value
+MOIU.map_indices(_, ::PostSampleCallback, value) = value
+MOIU.map_indices(_, ::_RawPostSampleCallback, value) = value
+MOIU.map_indices(_, ::PostSampleTransform, value) = value
+MOIU.map_indices(_, ::_RawPostSampleTransform, value) = value

--- a/src/interface/sampler.jl
+++ b/src/interface/sampler.jl
@@ -153,13 +153,23 @@ function _apply_post_sample_callback(
     return processed_sampleset, results.time
 end
 
+struct _PostSampleCallbackError <: Exception
+    error
+    backtrace
+end
+
+function Base.showerror(io::IO, err::_PostSampleCallbackError)
+    print(io, "PostSampleCallback failed: ")
+    showerror(io, err.error, err.backtrace)
+
+    return nothing
+end
+
 function _call_post_sample_callback(callback, sampleset, sampler)
     try
         return callback(sampleset, sampler)
     catch err
-        msg = sprint(showerror, err)
-
-        error("PostSampleCallback failed: $msg")
+        throw(_PostSampleCallbackError(err, catch_backtrace()))
     end
 end
 

--- a/src/interface/sampler.jl
+++ b/src/interface/sampler.jl
@@ -100,6 +100,9 @@ function _sample!(sampler::AbstractSampler{T}) where {T}
 end
 
 function _sample!(sampler::AbstractSampler{T}, sampleset::SampleSet{T}, total_time::Float64) where {T}
+    sampleset, post_sample_time = _apply_post_sample_callback(sampler, sampleset)
+    total_time += post_sample_time
+
     metadata = QUBOTools.metadata(sampleset)::Dict{String,Any}
 
     if !haskey(metadata, "time")
@@ -115,4 +118,150 @@ function _sample!(sampler::AbstractSampler{T}, sampleset::SampleSet{T}, total_ti
     QUBOTools.attach!(sampler, sampleset)
 
     return nothing
+end
+
+function _apply_post_sample_callback(
+    sampler::AbstractSampler{T},
+    sampleset::SampleSet{T},
+) where {T}
+    callback = post_sample_callback(sampler)
+
+    isnothing(callback) && return sampleset, 0.0
+
+    transform = post_sample_transform(sampler)
+    working_sampleset = _copy_sampleset(sampleset)
+    results = @timed _call_post_sample_callback(callback, working_sampleset, sampler)
+    processed_sampleset = _post_sample_result(results.value, working_sampleset)
+    transformed = !_same_samples(sampleset, processed_sampleset)
+
+    if transformed && !transform
+        error(
+            "PostSampleCallback changed sample states, values, reads, sense, or domain, " *
+            "but PostSampleTransform is false",
+        )
+    end
+
+    _record_post_sample_metadata!(
+        processed_sampleset,
+        callback;
+        transform,
+        transformed,
+        time = results.time,
+        raw_sampleset = transformed ? sampleset : nothing,
+    )
+
+    return processed_sampleset, results.time
+end
+
+function _call_post_sample_callback(callback, sampleset, sampler)
+    try
+        return callback(sampleset, sampler)
+    catch err
+        msg = sprint(showerror, err)
+
+        error("PostSampleCallback failed: $msg")
+    end
+end
+
+function _post_sample_result(result, fallback::SampleSet{T,U}) where {T,U}
+    if isnothing(result)
+        return fallback
+    elseif result isa SampleSet{T,U}
+        return result
+    elseif result isa SampleSet
+        error(
+            "PostSampleCallback returned '$(typeof(result))', expected " *
+            "'SampleSet{$T,$U}'",
+        )
+    else
+        error(
+            "PostSampleCallback returned '$(typeof(result))', expected " *
+            "'nothing' or 'SampleSet{$T,$U}'",
+        )
+    end
+end
+
+function _copy_sampleset(sampleset::SampleSet{T,U}) where {T,U}
+    samples = [
+        Sample{T,U}(
+            copy(QUBOTools.state(sample)),
+            QUBOTools.value(sample),
+            QUBOTools.reads(sample),
+        ) for sample in sampleset
+    ]
+
+    return SampleSet{T,U}(
+        samples;
+        metadata = deepcopy(QUBOTools.metadata(sampleset)),
+        sense    = QUBOTools.sense(sampleset),
+        domain   = QUBOTools.domain(sampleset),
+    )
+end
+
+function _same_samples(left::SampleSet, right::SampleSet)
+    QUBOTools.sense(left) === QUBOTools.sense(right) || return false
+    QUBOTools.domain(left) === QUBOTools.domain(right) || return false
+    length(left) == length(right) || return false
+
+    for (left_sample, right_sample) in zip(left, right)
+        QUBOTools.state(left_sample) == QUBOTools.state(right_sample) || return false
+        QUBOTools.value(left_sample) == QUBOTools.value(right_sample) || return false
+        QUBOTools.reads(left_sample) == QUBOTools.reads(right_sample) || return false
+    end
+
+    return true
+end
+
+function _record_post_sample_metadata!(
+    sampleset::SampleSet,
+    callback;
+    transform::Bool,
+    transformed::Bool,
+    time::Float64,
+    raw_sampleset::Union{SampleSet,Nothing},
+)
+    metadata = QUBOTools.metadata(sampleset)::Dict{String,Any}
+    postprocess = _post_sample_metadata(metadata)
+
+    postprocess["callback"] = Dict{String,Any}(
+        "type"        => string(typeof(callback)),
+        "transform"   => transform,
+        "transformed" => transformed,
+        "time"        => time,
+    )
+
+    if !isnothing(raw_sampleset)
+        postprocess["raw_samples"] = _sample_records(raw_sampleset)
+    end
+
+    return nothing
+end
+
+function _post_sample_metadata(metadata::Dict{String,Any})
+    current = get(metadata, "postprocess", nothing)
+
+    postprocess = if current isa Dict{String,Any}
+        current
+    elseif current isa AbstractDict
+        Dict{String,Any}(string(key) => value for (key, value) in current)
+    elseif isnothing(current)
+        Dict{String,Any}()
+    else
+        Dict{String,Any}("user" => current)
+    end
+
+    metadata["postprocess"] = postprocess
+
+    return postprocess
+end
+
+function _sample_records(sampleset::SampleSet)
+    return [
+        Dict{String,Any}(
+            "rank"  => i,
+            "state" => copy(QUBOTools.state(sample)),
+            "value" => QUBOTools.value(sample),
+            "reads" => QUBOTools.reads(sample),
+        ) for (i, sample) in enumerate(sampleset)
+    ]
 end

--- a/src/interface/sampler.jl
+++ b/src/interface/sampler.jl
@@ -231,7 +231,7 @@ function _record_post_sample_metadata!(
     )
 
     if !isnothing(raw_sampleset)
-        postprocess["raw_samples"] = _sample_records(raw_sampleset)
+        postprocess["raw_samples"] = _sampleset_record(raw_sampleset)
     end
 
     return nothing
@@ -253,6 +253,16 @@ function _post_sample_metadata(metadata::Dict{String,Any})
     metadata["postprocess"] = postprocess
 
     return postprocess
+end
+
+function _sampleset_record(sampleset::SampleSet)
+    return Dict{String,Any}(
+        "format"         => "QUBODrivers.raw_samples",
+        "schema_version" => 1,
+        "sense"          => String(QUBOTools.sense(sampleset)),
+        "domain"         => String(QUBOTools.domain(sampleset)),
+        "samples"        => _sample_records(sampleset),
+    )
 end
 
 function _sample_records(sampleset::SampleSet)

--- a/src/library/setup/quote.jl
+++ b/src/library/setup/quote.jl
@@ -297,6 +297,59 @@ function __setup_quote_qubodrivers_attrs(spec::_SamplerSpec)
             ::$(Optimizer),
             ::Union{QUBODrivers.FinalNumberOfReads,QUBODrivers._RawFinalNumberOfReads},
         ) = true
+
+        # QUBODrivers.PostSampleCallback - get
+        function MOI.get(sampler::$(Optimizer), ::QUBODrivers.PostSampleCallback)
+            return QUBODrivers.post_sample_callback(sampler)
+        end
+
+        QUBODrivers.default_raw_attr(
+            ::$(Optimizer),
+            ::QUBODrivers._RawPostSampleCallback,
+        ) = nothing
+
+        # QUBODrivers.PostSampleCallback - set
+        function MOI.set(sampler::$(Optimizer), ::QUBODrivers.PostSampleCallback, value)
+            return MOI.set(sampler, QUBODrivers._RawPostSampleCallback(), value)
+        end
+
+        # QUBODrivers.PostSampleCallback - support
+        MOI.supports(
+            ::$(Optimizer),
+            ::Union{QUBODrivers.PostSampleCallback,QUBODrivers._RawPostSampleCallback},
+        ) = true
+
+        # QUBODrivers.PostSampleTransform - get
+        function MOI.get(sampler::$(Optimizer), ::QUBODrivers.PostSampleTransform)
+            return QUBODrivers.post_sample_transform(sampler)
+        end
+
+        QUBODrivers.default_raw_attr(
+            ::$(Optimizer),
+            ::QUBODrivers._RawPostSampleTransform,
+        ) = false
+
+        # QUBODrivers.PostSampleTransform - set
+        function MOI.set(sampler::$(Optimizer), ::QUBODrivers.PostSampleTransform, value)
+            return MOI.set(sampler, QUBODrivers._RawPostSampleTransform(), value)
+        end
+
+        function MOI.set(
+            sampler::$(Optimizer),
+            attr::QUBODrivers._RawPostSampleTransform,
+            value,
+        )
+            QUBODrivers._validate_post_sample_transform(value)
+            QUBODrivers.set_raw_attr!(sampler, attr, value)
+
+            return nothing
+        end
+
+        # QUBODrivers.PostSampleTransform - support
+        MOI.supports(
+            ::$(Optimizer),
+            ::Union{QUBODrivers.PostSampleTransform,QUBODrivers._RawPostSampleTransform},
+        ) = true
     end
 end
 

--- a/test/drivers/random_sampler.jl
+++ b/test/drivers/random_sampler.jl
@@ -125,6 +125,7 @@ function _test_random_sampler_final_number_of_reads_sampling()
         default_metadata = _solution_metadata(default_model)
 
         @test _random_total_reads(default_model) == 7
+        @test !haskey(default_metadata, "postprocess")
         _assert_sampler_metadata_schema(
             default_metadata;
             algorithm_name        = "Random Sampler",
@@ -252,7 +253,8 @@ function _test_random_sampler_post_sample_error()
         err = _optimize_error(model)
         msg = sprint(showerror, err)
 
-        @test err isa ErrorException
+        @test err isa QUBODrivers._PostSampleCallbackError
+        @test err.error isa ErrorException
         @test occursin("PostSampleCallback failed", msg)
         @test occursin("callback boom", msg)
     end

--- a/test/drivers/random_sampler.jl
+++ b/test/drivers/random_sampler.jl
@@ -36,6 +36,41 @@ function _random_total_reads(model)
     )
 end
 
+function _random_solution(model)
+    raw = MOI.get(model, MOI.RawSolver())
+
+    return QUBOTools.solution(raw)
+end
+
+function _offset_sampleset_values(sampleset::SampleSet{T,U}, offset::T) where {T,U}
+    samples = Sample{T,U}[
+        Sample{T,U}(
+            copy(QUBOTools.state(sample)),
+            QUBOTools.value(sample) + offset,
+            QUBOTools.reads(sample),
+        ) for sample in sampleset
+    ]
+    metadata = QUBOTools.metadata(sampleset)
+    metadata["alternative_objective"] = Dict{String,Any}("offset" => offset)
+
+    return SampleSet{T,U}(
+        samples;
+        metadata,
+        sense  = QUBOTools.sense(sampleset),
+        domain = QUBOTools.domain(sampleset),
+    )
+end
+
+function _optimize_error(model)
+    try
+        MOI.optimize!(model)
+
+        return nothing
+    catch err
+        return err
+    end
+end
+
 function _test_random_sampler_final_number_of_reads_attribute()
     @testset "FinalNumberOfReads attribute" begin
         sampler = RandomSampler.Optimizer()
@@ -104,12 +139,107 @@ function _test_random_sampler_final_number_of_reads_sampling()
     return nothing
 end
 
+function _test_random_sampler_post_sample_annotation()
+    @testset "PostSampleCallback annotation" begin
+        model = _build_random_reads_model(; num_reads = 2, final_num_reads = 2)
+        callback = (sampleset, sampler) -> begin
+            QUBOTools.metadata(sampleset)["annotation"] = Dict{String,Any}(
+                "samples"   => length(sampleset),
+                "variables" => MOI.get(sampler, MOI.NumberOfVariables()),
+            )
+
+            return nothing
+        end
+
+        MOI.set(model, QUBODrivers.PostSampleCallback(), callback)
+        MOI.optimize!(model)
+
+        metadata = _solution_metadata(model)
+
+        @test metadata["annotation"]["samples"] == MOI.get(model, MOI.ResultCount())
+        @test metadata["annotation"]["variables"] == 2
+        @test metadata["postprocess"]["callback"]["transform"] === false
+        @test metadata["postprocess"]["callback"]["transformed"] === false
+        @test haskey(metadata["postprocess"]["callback"], "time")
+        @test !haskey(metadata["postprocess"], "raw_samples")
+    end
+
+    return nothing
+end
+
+function _test_random_sampler_post_sample_transform()
+    @testset "PostSampleCallback transform" begin
+        model = _build_random_reads_model(; num_reads = 1, final_num_reads = 1)
+        callback = (sampleset, _) -> _offset_sampleset_values(sampleset, 10.0)
+
+        MOI.set(model, QUBODrivers.PostSampleCallback(), callback)
+        MOI.set(model, QUBODrivers.PostSampleTransform(), true)
+        MOI.optimize!(model)
+
+        solution = _random_solution(model)
+        metadata = QUBOTools.metadata(solution)
+        raw_samples = metadata["postprocess"]["raw_samples"]
+
+        @test metadata["alternative_objective"]["offset"] == 10.0
+        @test metadata["postprocess"]["callback"]["transform"] === true
+        @test metadata["postprocess"]["callback"]["transformed"] === true
+        @test length(raw_samples) == length(solution)
+
+        for i in eachindex(raw_samples)
+            @test raw_samples[i]["state"] == QUBOTools.state(solution[i])
+            @test raw_samples[i]["reads"] == QUBOTools.reads(solution[i])
+            @test QUBOTools.value(solution[i]) == raw_samples[i]["value"] + 10.0
+        end
+    end
+
+    return nothing
+end
+
+function _test_random_sampler_post_sample_transform_gate()
+    @testset "PostSampleCallback transform gate" begin
+        model = _build_random_reads_model(; num_reads = 1, final_num_reads = 1)
+        callback = (sampleset, _) -> _offset_sampleset_values(sampleset, 10.0)
+
+        MOI.set(model, QUBODrivers.PostSampleCallback(), callback)
+
+        err = _optimize_error(model)
+        msg = sprint(showerror, err)
+
+        @test err isa ErrorException
+        @test occursin("PostSampleTransform is false", msg)
+    end
+
+    return nothing
+end
+
+function _test_random_sampler_post_sample_error()
+    @testset "PostSampleCallback error" begin
+        model = _build_random_reads_model(; num_reads = 1, final_num_reads = 1)
+        callback = (_, _) -> error("callback boom")
+
+        MOI.set(model, MOI.RawOptimizerAttribute("post_sample_callback"), callback)
+
+        err = _optimize_error(model)
+        msg = sprint(showerror, err)
+
+        @test err isa ErrorException
+        @test occursin("PostSampleCallback failed", msg)
+        @test occursin("callback boom", msg)
+    end
+
+    return nothing
+end
+
 function test_random_sampler()
     QUBODrivers.test(RandomSampler.Optimizer)
 
     @testset "□ RandomSampler" verbose = true begin
         _test_random_sampler_final_number_of_reads_attribute()
         _test_random_sampler_final_number_of_reads_sampling()
+        _test_random_sampler_post_sample_annotation()
+        _test_random_sampler_post_sample_transform()
+        _test_random_sampler_post_sample_transform_gate()
+        _test_random_sampler_post_sample_error()
     end
 
     return nothing

--- a/test/drivers/random_sampler.jl
+++ b/test/drivers/random_sampler.jl
@@ -42,6 +42,22 @@ function _random_solution(model)
     return QUBOTools.solution(raw)
 end
 
+function _objective_rows(sampleset::SampleSet{T,U}; offset::T = zero(T)) where {T,U}
+    return [
+        Dict{String,Any}(
+            "rank"                  => i,
+            "state"                 => copy(QUBOTools.state(sample)),
+            "raw_value"             => QUBOTools.value(sample),
+            "scaled_value"          => QUBOTools.value(sample),
+            "offset_adjusted_value" => QUBOTools.value(sample) + offset,
+            "scale"                 => one(T),
+            "offset"                => offset,
+            "sense"                 => String(QUBOTools.sense(sampleset)),
+            "domain"                => String(QUBOTools.domain(sampleset)),
+        ) for (i, sample) in enumerate(sampleset)
+    ]
+end
+
 function _offset_sampleset_values(sampleset::SampleSet{T,U}, offset::T) where {T,U}
     samples = Sample{T,U}[
         Sample{T,U}(
@@ -51,7 +67,10 @@ function _offset_sampleset_values(sampleset::SampleSet{T,U}, offset::T) where {T
         ) for sample in sampleset
     ]
     metadata = QUBOTools.metadata(sampleset)
-    metadata["alternative_objective"] = Dict{String,Any}("offset" => offset)
+    objectives = get!(metadata, "objectives") do
+        Dict{String,Any}()
+    end
+    objectives["shifted"] = _objective_rows(sampleset; offset)
 
     return SampleSet{T,U}(
         samples;
@@ -147,6 +166,10 @@ function _test_random_sampler_post_sample_annotation()
                 "samples"   => length(sampleset),
                 "variables" => MOI.get(sampler, MOI.NumberOfVariables()),
             )
+            objectives = get!(QUBOTools.metadata(sampleset), "objectives") do
+                Dict{String,Any}()
+            end
+            objectives["callback"] = _objective_rows(sampleset)
 
             return nothing
         end
@@ -158,6 +181,8 @@ function _test_random_sampler_post_sample_annotation()
 
         @test metadata["annotation"]["samples"] == MOI.get(model, MOI.ResultCount())
         @test metadata["annotation"]["variables"] == 2
+        @test length(metadata["objectives"]["callback"]) == MOI.get(model, MOI.ResultCount())
+        @test haskey(first(metadata["objectives"]["callback"]), "offset_adjusted_value")
         @test metadata["postprocess"]["callback"]["transform"] === false
         @test metadata["postprocess"]["callback"]["transformed"] === false
         @test haskey(metadata["postprocess"]["callback"], "time")
@@ -178,9 +203,14 @@ function _test_random_sampler_post_sample_transform()
 
         solution = _random_solution(model)
         metadata = QUBOTools.metadata(solution)
-        raw_samples = metadata["postprocess"]["raw_samples"]
+        raw_sampleset = metadata["postprocess"]["raw_samples"]
+        raw_samples = raw_sampleset["samples"]
 
-        @test metadata["alternative_objective"]["offset"] == 10.0
+        @test metadata["objectives"]["shifted"][1]["offset"] == 10.0
+        @test raw_sampleset["format"] == "QUBODrivers.raw_samples"
+        @test raw_sampleset["schema_version"] == 1
+        @test raw_sampleset["sense"] == String(QUBOTools.sense(solution))
+        @test raw_sampleset["domain"] == String(QUBOTools.domain(solution))
         @test metadata["postprocess"]["callback"]["transform"] === true
         @test metadata["postprocess"]["callback"]["transformed"] === true
         @test length(raw_samples) == length(solution)

--- a/test/setup/setup.jl
+++ b/test/setup/setup.jl
@@ -4,6 +4,7 @@ function test_setup_macro()
         test_setup_spec_parser()
         test_final_number_of_reads_fallbacks()
         test_post_sample_attribute_defaults()
+        test_post_sample_callback_optimize_fallbacks()
     end
 
     return nothing
@@ -56,12 +57,55 @@ function test_post_sample_attribute_defaults()
     return nothing
 end
 
-struct NoRawAttributeSampler <: QUBODrivers.AbstractSampler{Float64} end
+mutable struct NoRawAttributeSampler <: QUBODrivers.AbstractSampler{Float64}
+    model::QUBOTools.Model{VI,Float64,Int}
 
-struct ThrowingRawAttributeSampler <: QUBODrivers.AbstractSampler{Float64} end
+    NoRawAttributeSampler() = new(QUBOTools.Model{VI,Float64,Int}())
+end
+
+mutable struct ThrowingRawAttributeSampler <: QUBODrivers.AbstractSampler{Float64}
+    model::QUBOTools.Model{VI,Float64,Int}
+
+    ThrowingRawAttributeSampler() = new(QUBOTools.Model{VI,Float64,Int}())
+end
+
+QUBOTools.backend(sampler::NoRawAttributeSampler) = sampler.model
+QUBOTools.backend(sampler::ThrowingRawAttributeSampler) = sampler.model
+
+function QUBODrivers.set_model!(
+    sampler::Union{NoRawAttributeSampler,ThrowingRawAttributeSampler},
+    model::QUBOTools.Model{VI,Float64,Int},
+)
+    sampler.model = model
+
+    return model
+end
+
+function _custom_sampleset()
+    metadata = QUBODrivers._sampler_metadata(
+        origin                = "Custom Sampler",
+        algorithm_name        = "Custom Sampler",
+        execution_mode        = "test",
+        optimizer_iterations  = 1,
+        optimizer_evaluations = 1,
+        number_of_reads       = 1,
+        final_number_of_reads = 1,
+        status                = "locally_solved",
+    )
+    samples = [QUBOTools.Sample{Float64,Int}([0], 0.0)]
+
+    return QUBOTools.SampleSet{Float64,Int}(samples, metadata; sense = :min, domain = :bool)
+end
+
+QUBODrivers.sample(::NoRawAttributeSampler) = _custom_sampleset()
+QUBODrivers.sample(::ThrowingRawAttributeSampler) = _custom_sampleset()
 
 function MOI.get(::ThrowingRawAttributeSampler, ::QUBODrivers._RawFinalNumberOfReads)
     error("raw final reads failure")
+end
+
+function MOI.get(::ThrowingRawAttributeSampler, ::QUBODrivers._RawPostSampleCallback)
+    error("raw post-sample callback failure")
 end
 
 function test_final_number_of_reads_fallbacks()
@@ -70,6 +114,35 @@ function test_final_number_of_reads_fallbacks()
         @test_throws ErrorException QUBODrivers.final_number_of_reads(
             ThrowingRawAttributeSampler(),
         )
+    end
+
+    return nothing
+end
+
+function test_post_sample_callback_optimize_fallbacks()
+    @testset "→ PostSampleCallback optimize fallbacks" begin
+        sampler = NoRawAttributeSampler()
+
+        MOI.optimize!(sampler)
+
+        metadata = QUBOTools.metadata(QUBOTools.solution(sampler))
+
+        @test QUBODrivers.post_sample_callback(sampler) === nothing
+        @test QUBODrivers.post_sample_transform(sampler) === false
+        @test !haskey(metadata, "postprocess")
+
+        throwing_sampler = ThrowingRawAttributeSampler()
+        err = try
+            MOI.optimize!(throwing_sampler)
+
+            nothing
+        catch err
+            err
+        end
+        msg = sprint(showerror, err)
+
+        @test err isa ErrorException
+        @test occursin("raw post-sample callback failure", msg)
     end
 
     return nothing

--- a/test/setup/setup.jl
+++ b/test/setup/setup.jl
@@ -3,6 +3,7 @@ function test_setup_macro()
         test_project_version()
         test_setup_spec_parser()
         test_final_number_of_reads_fallbacks()
+        test_post_sample_attribute_defaults()
     end
 
     return nothing
@@ -17,6 +18,39 @@ function test_project_version()
         @test MOI.get(ExactSampler.Optimizer(), MOI.SolverVersion()) == version
         @test MOI.get(RandomSampler.Optimizer(), MOI.SolverVersion()) == version
         @test MOI.get(IdentitySampler.Optimizer(), MOI.SolverVersion()) == version
+    end
+
+    return nothing
+end
+
+function test_post_sample_attribute_defaults()
+    @testset "→ Post-sample callback attributes" begin
+        sampler = RandomSampler.Optimizer()
+        callback = (_, _) -> nothing
+
+        @test MOI.supports(sampler, QUBODrivers.PostSampleCallback())
+        @test MOI.supports(sampler, MOI.RawOptimizerAttribute("post_sample_callback"))
+        @test MOI.supports(sampler, QUBODrivers.PostSampleTransform())
+        @test MOI.supports(sampler, MOI.RawOptimizerAttribute("post_sample_transform"))
+        @test MOI.get(sampler, QUBODrivers.PostSampleCallback()) === nothing
+        @test MOI.get(sampler, MOI.RawOptimizerAttribute("post_sample_callback")) === nothing
+        @test MOI.get(sampler, QUBODrivers.PostSampleTransform()) === false
+        @test MOI.get(sampler, MOI.RawOptimizerAttribute("post_sample_transform")) === false
+        @test QUBODrivers.post_sample_callback(sampler) === nothing
+        @test QUBODrivers.post_sample_transform(sampler) === false
+
+        MOI.set(sampler, QUBODrivers.PostSampleCallback(), callback)
+        @test MOI.get(sampler, QUBODrivers.PostSampleCallback()) === callback
+
+        MOI.set(sampler, MOI.RawOptimizerAttribute("post_sample_transform"), true)
+        @test MOI.get(sampler, QUBODrivers.PostSampleTransform()) === true
+        @test QUBODrivers.post_sample_transform(sampler) === true
+
+        @test_throws ErrorException MOI.set(
+            sampler,
+            QUBODrivers.PostSampleTransform(),
+            "true",
+        )
     end
 
     return nothing


### PR DESCRIPTION
Summary:
- Add generic `PostSampleCallback` / `PostSampleTransform` attributes and raw `"post_sample_callback"` / `"post_sample_transform"` support for generated samplers.
- Apply callbacks at the shared `_sample!` boundary with defensive `SampleSet` copying, metadata recording, transform-gate enforcement, callback error wrapping, and raw-sample preservation for transformed outputs.
- Preserve transformed raw samples as a JSON-compatible frame record with `format`, `schema_version`, `sense`, `domain`, and per-sample state/value/read rows.
- Align callback objective annotations with QUBOTools #96 by documenting and testing the `metadata(sampleset)["objectives"][label]` convention.
- Document the package-boundary decision after ToQUBO #133: QUBODrivers owns the hook; ToQUBO/QUBOTools own reformulation metadata, original-variable projection, objective bookkeeping, and encoding-specific repair logic.

Tests:
- `julia +release --project=. -e "using QUBODrivers; println("loaded")"` passed.
- `julia +release --project=. -e "using Pkg; Pkg.test()"` passed, 872/872 tests after the QUBOTools #96 / ToQUBO #133 alignment revision.
- `julia +release --project=docs docs/make.jl --skip-deploy` passed.
- `git diff --check` passed.

Notes:
- This builds on the merged QUBODrivers #42 final-read and metadata path.
- This intentionally does not add a ToQUBO dependency to QUBODrivers.

Closes #41