### PR TITLE
Benchmark julia-actions/cache for CI runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
Summary:
- Adds `julia-actions/cache@v3` to the Julia CI test job.
- Places the cache step after `julia-actions/setup-julia@v3` and before `julia-actions/julia-buildpkg@v1`.
- Leaves package code unchanged.

Local checks:
- `bash .github/tests/doc_preview_cleanup.sh` passed.
- `python -m unittest discover -s .github/tests -p 'test_*.py'` passed.
- `actionlint .github/workflows/ci.yml` passed.
- `git diff --check` passed.

CI benchmark:
- Run: https://github.com/JuliaQUBO/QUBODrivers.jl/actions/runs/27122901630
- Attempt 1 populated caches and passed.
- Attempt 2 restored caches from attempt 1, saved fresh caches, and passed.

Baseline vs measured totals:

| Job | Issue baseline | Attempt 1 | Attempt 2 warm | Warm vs baseline |
| --- | ---: | ---: | ---: | ---: |
| Julia 1.10 Ubuntu | 3m04s | 3m02s | 2m04s | -60s |
| Julia 1 Ubuntu | 4m38s | 4m39s | 2m11s | -147s |
| Julia 1.10 Windows | 3m04s | 4m27s | 3m37s | +33s |
| Julia 1 Windows | 5m40s | 5m39s | 3m04s | -156s |

Warm-cache critical path:
- Baseline slowest Julia job: 5m40s.
- Warm slowest Julia job: 3m37s.
- Improvement: 123s, about 36%.

Attempt 1 step timings, seconds:

| Job | Total | setup-julia | cache restore | buildpkg | runtest | coverage | upload | cache save |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: |
| Julia 1 Windows | 339 | 18 | 2 | 36 | 230 | 22 | skipped | 17 |
| Julia 1.10 Windows | 267 | 8 | 0 | 36 | 177 | 21 | skipped | 11 |
| Julia 1.10 Ubuntu | 182 | 5 | 1 | 16 | 127 | 18 | skipped | 7 |
| Julia 1 Ubuntu | 279 | 8 | 1 | 12 | 223 | 23 | skipped | 6 |

Attempt 2 warm-cache step timings, seconds:

| Job | Total | setup-julia | cache restore | buildpkg | runtest | coverage | upload | cache save |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: |
| Julia 1 Ubuntu | 131 | 8 | 5 | 8 | 93 | 5 | skipped | 7 |
| Julia 1 Windows | 184 | 18 | 26 | 9 | 93 | 3 | skipped | 21 |
| Julia 1.10 Windows | 217 | 9 | 28 | 17 | 117 | 22 | skipped | 12 |
| Julia 1.10 Ubuntu | 124 | 6 | 5 | 11 | 79 | 7 | skipped | 7 |

Cache evidence:
- Attempt 1 logs show `Cache saved successfully` for all four Julia matrix jobs.
- Attempt 2 logs show cache hits/restores from attempt 1 for all four Julia matrix jobs, followed by `Cache saved successfully`.

Closes #45
