### PR TITLE
Standardize benchmarking metadata schema

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,6 +26,7 @@ makedocs(;
             "Implementing a Sampler" => "manual/7-integration.md",
             "Test Suite"    => "manual/5-tests.md",
             "Benchmarking"  => "manual/6-benchmarks.md",
+            "Metadata Schema" => "manual/metadata.md",
             "API Reference" => "manual/8-api.md",
         ],
         "Booklet" => [

--- a/docs/src/manual/2-solve.md
+++ b/docs/src/manual/2-solve.md
@@ -76,7 +76,7 @@ directly through MOI:
 ```julia
 optimizer = RandomSampler.Optimizer()
 MOI.set(optimizer, RandomSampler.NumberOfReads(), 10)
-MOI.set(optimizer, RandomSampler.RandomSeed(), 123)
+MOI.set(optimizer, QUBODrivers.RandomSeed(), 123)
 ```
 
 ## Fixed Variables and Starts

--- a/docs/src/manual/4-setup.md
+++ b/docs/src/manual/4-setup.md
@@ -85,6 +85,21 @@ evaluations. `"final_num_reads"` controls the reads used to build the returned
 `QUBODrivers.final_number_of_reads(sampler)` to get the effective value; it
 defaults to `"num_reads"` when that attribute is supported.
 
+Declare raw `"seed"` to opt into the standard `QUBODrivers.RandomSeed()`
+attribute:
+
+```julia
+QUBODrivers.@setup Optimizer begin
+    name = "Seeded Sampler"
+    attributes = begin
+        "seed"::Union{Integer,Nothing} = nothing
+    end
+end
+```
+
+When a seed is configured, QUBODrivers records it under
+`metadata["seeds"]["sampler"]` after sampling.
+
 Generated optimizers also support a generic post-sampling hook through
 `QUBODrivers.PostSampleCallback()` and the raw key
 `"post_sample_callback"`. The callback is called after
@@ -154,10 +169,13 @@ The `sense` keyword (`:min` or `:max`) and `domain` (`:bool` or `:spin`) tell QU
 The metadata dictionary is the place to record backend status, timing, and
 diagnostics. QUBODrivers will add a total time and empty status string if they
 are missing, but backend-specific wrappers should provide as much useful
-metadata as their solver exposes.
+metadata as their solver exposes. See the [Metadata Schema](@ref) for the
+normative benchmarking contract.
 
-QUBODrivers recommends these top-level metadata keys for driver attributes:
+QUBODrivers requires these top-level metadata keys for benchmark-ready driver
+results:
 
+- `"origin"`: human-readable driver or backend origin;
 - `"algorithm"`: dictionary with at least `"name"`;
 - `"backend"`: dictionary with backend `"name"` and `"version"` when known;
 - `"execution"`: dictionary with `"mode"`;
@@ -166,7 +184,7 @@ QUBODrivers recommends these top-level metadata keys for driver attributes:
 - `"reads"`: dictionary with `"number_of_reads"` and
   `"final_number_of_reads"` counts actually consumed by internal search and
   final sample-set construction, respectively; if there is no separate
-  internal phase, both values may be the same;
+  internal phase, both values should be the same;
 - `"seeds"`: dictionary of sampler, model, optimizer, or backend seeds;
 - `"status"` and `"termination_status"`: raw and structured termination status.
 
@@ -174,6 +192,20 @@ When a post-sampling callback runs, QUBODrivers records callback metadata under
 `"postprocess" => "callback"`. If the callback transforms emitted samples, the
 raw sample frame and records are stored under
 `"postprocess" => "raw_samples"`.
+
+## Sampler checklist
+
+Before releasing a driver wrapper, confirm that:
+
+- `QUBODrivers.validate_metadata(sampleset)` returns an empty vector for normal
+  results; see the [Metadata Schema](@ref);
+- stochastic samplers expose raw `"seed"` and support
+  `QUBODrivers.RandomSeed()` when reproducibility is part of their contract;
+- `QUBODrivers.honors_final_reads` and
+  `QUBODrivers.enforces_time_limit` return `true` only for behavior the driver
+  actually guarantees;
+- `MOI.get(sampler, MOI.SolveTimeSec())` reports effective backend time, while
+  wall-clock time is available through `QUBODrivers.total_time`.
 
 ## A complete example
 
@@ -225,6 +257,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
 
     # ~ Store some metadata ~ #
     metadata = Dict{String,Any}(
+        "origin"    => "Super Sampler @ SuperBackend",
         "algorithm" => Dict{String,Any}("name" => "Super Sampler"),
         "backend"   => Dict{String,Any}("name" => "SuperBackend", "version" => nothing),
         "execution" => Dict{String,Any}("mode" => "sampling"),

--- a/docs/src/manual/6-benchmarks.md
+++ b/docs/src/manual/6-benchmarks.md
@@ -90,11 +90,17 @@ benchmark.
 
 ## Timing Information
 
-Samplers store timing metadata in the returned sample set. After solving,
-`MOI.get(backend(model), MOI.SolveTimeSec())` returns the effective solve time
-reported through MOI. This can differ from wall-clock timing around
-`optimize!`, especially for wrappers that separate model conversion, backend
-submission, queue time, and sample decoding.
+Samplers store timing metadata in the returned sample set. The standardized
+entries are `metadata["time"]["total"]`, the QUBODrivers wall-clock time around
+the sampling pipeline, and `metadata["time"]["effective"]`, the backend
+solve/sampling time reported by the driver.
+
+After solving, `MOI.get(backend(model), MOI.SolveTimeSec())` returns effective
+time. Use `QUBODrivers.total_time(sampleset)` or
+`QUBODrivers.total_time(sampler)` when the benchmark needs framework-inclusive
+wall time. This can differ from timing around `optimize!`, especially for
+wrappers that separate model conversion, backend submission, queue time, and
+sample decoding. See the [Metadata Schema](@ref) for the full contract.
 
 ## What to Report
 

--- a/docs/src/manual/8-api.md
+++ b/docs/src/manual/8-api.md
@@ -23,12 +23,20 @@ QUBODrivers.set_model!
 ```@docs; canonical=false
 QUBODrivers.@setup
 QUBODrivers.SamplerAttribute
+QUBODrivers.RandomSeed
+QUBODrivers.random_seed
 QUBODrivers.FinalNumberOfReads
 QUBODrivers.final_number_of_reads
 QUBODrivers.PostSampleCallback
 QUBODrivers.PostSampleTransform
 QUBODrivers.post_sample_callback
 QUBODrivers.post_sample_transform
+QUBODrivers.total_time
+QUBODrivers.effective_time
+QUBODrivers.validate_metadata
+QUBODrivers.supports_seed
+QUBODrivers.honors_final_reads
+QUBODrivers.enforces_time_limit
 QUBODrivers.RawSamplerAttribute
 QUBODrivers.@raw_attr_str
 QUBODrivers.get_raw_attr

--- a/docs/src/manual/metadata.md
+++ b/docs/src/manual/metadata.md
@@ -1,0 +1,106 @@
+# Metadata Schema
+
+Sampler metadata is the contract between a driver and benchmarking or
+conformance tooling. Every `SampleSet` returned through `MOI.optimize!` should
+carry the fields below. QUBODrivers validates this schema after it stamps
+framework metadata and emits a warning, not an error, for violations.
+
+Use `QUBODrivers.validate_metadata(sampleset)` to check a result directly. The
+function returns a vector of human-readable violations; an empty vector means
+the metadata satisfies the current schema.
+
+## Required Fields
+
+| Field | Type | Required | Stamped by | Meaning |
+| --- | --- | --- | --- | --- |
+| `metadata["origin"]` | `String` | yes | driver | Human-readable driver or backend origin. |
+| `metadata["algorithm"]["name"]` | `String` | yes | driver | Algorithm or sampler name used for grouping benchmark rows. |
+| `metadata["backend"]["name"]` | `String` | yes | driver | Backend package, service, or solver name. |
+| `metadata["backend"]["version"]` | `VersionNumber`, `String`, or `nothing` | yes | driver | Backend version when known. Use `nothing` only when the backend cannot report one. |
+| `metadata["status"]` | `String` | yes | driver or QUBODrivers fallback | Raw status string suitable for logs and reports. |
+| `metadata["reads"]["number_of_reads"]` | non-negative `Integer` | yes | driver | Reads, evaluations, or backend samples actually consumed by the sampler. |
+| `metadata["reads"]["final_number_of_reads"]` | non-negative `Integer` | yes | driver | Number of reads represented in the final emitted `SampleSet`. |
+| `metadata["seeds"]` | dictionary with string keys | yes | driver and QUBODrivers seed recorder | Seed values used by the sampler, backend, model generator, or optimizer. Empty is valid for deterministic solvers. |
+| `metadata["time"]["total"]` | non-negative `Real` | yes | QUBODrivers | Wall-clock seconds around `sample`, post-sample callbacks, and attachment preparation. |
+| `metadata["time"]["effective"]` | non-negative `Real` | yes | driver | Backend solve or sampling seconds, excluding framework overhead when the backend exposes that split. |
+
+Drivers may include additional metadata fields for backend diagnostics. Prefer
+string keys and stable, machine-readable values.
+
+## Timing
+
+`metadata["time"]` has two standardized entries:
+
+- `"total"` is QUBODrivers wall-clock time. It is always stamped by the
+  framework when `MOI.optimize!` attaches a result.
+- `"effective"` is backend solve or sampling time. The driver must stamp it.
+
+Additional timing fields are optional. Use concise names such as `"build"`,
+`"queue"`, or `"decode"` when their meaning is clear for the backend, or a
+nested dictionary when a driver needs a namespaced breakdown.
+
+`MOI.get(sampler, MOI.SolveTimeSec())` returns
+`QUBODrivers.effective_time(sampler)`, not total wall-clock time. Use
+`QUBODrivers.total_time(sampler)` or `QUBODrivers.total_time(sampleset)` when a
+benchmark needs framework-inclusive wall time.
+
+## Seeds
+
+Generated optimizers opt into the standard seed contract by declaring raw
+`"seed"` in their `@setup` attributes:
+
+```julia
+QUBODrivers.@setup Optimizer begin
+    name = "Example Sampler"
+    attributes = begin
+        "seed"::Union{Integer,Nothing} = nothing
+    end
+end
+```
+
+Users can then call `MOI.set(sampler, QUBODrivers.RandomSeed(), 123)` or set
+the raw optimizer attribute `"seed"`. When a non-`nothing` seed is configured,
+QUBODrivers records it as `metadata["seeds"]["sampler"]` after sampling.
+
+Use `QUBODrivers.supports_seed(sampler)` to decide whether a benchmark harness
+can set `QUBODrivers.RandomSeed()` without driver-specific special cases.
+
+## Capability Traits
+
+QUBODrivers exposes conservative trait functions for benchmark harnesses:
+
+- `QUBODrivers.supports_seed(sampler)` reports support for
+  `QUBODrivers.RandomSeed()`.
+- `QUBODrivers.honors_final_reads(sampler)` reports whether
+  `QUBODrivers.FinalNumberOfReads()` controls the final emitted read count.
+- `QUBODrivers.enforces_time_limit(sampler)` reports whether
+  `MOI.TimeLimitSec()` is enforced by the sampler contract.
+
+The default for each trait is `false`. Drivers should define a method returning
+`true` only when the behavior is part of their public contract. Forwarding a
+time limit to a backend is not the same as guaranteeing enforcement unless the
+driver can rely on that backend behavior.
+
+## Validation
+
+```julia
+violations = QUBODrivers.validate_metadata(sampleset)
+isempty(violations) || @warn "metadata is not benchmark-ready" violations
+```
+
+`MOI.optimize!` runs the same validation after framework metadata is stamped.
+Violations are warnings so existing drivers have a migration path, but
+conformance tests can choose to fail on any non-empty violation list.
+
+## API
+
+```@docs
+QUBODrivers.RandomSeed
+QUBODrivers.random_seed
+QUBODrivers.total_time
+QUBODrivers.effective_time
+QUBODrivers.validate_metadata
+QUBODrivers.supports_seed
+QUBODrivers.honors_final_reads
+QUBODrivers.enforces_time_limit
+```

--- a/src/QUBODrivers.jl
+++ b/src/QUBODrivers.jl
@@ -48,8 +48,11 @@ include("library/setup/parse.jl")
 include("library/setup/quote.jl")
 include("library/setup/macro.jl")
 
-export AbstractSampler, FinalNumberOfReads, final_number_of_reads
+export AbstractSampler, RandomSeed, random_seed
+export FinalNumberOfReads, final_number_of_reads
 export PostSampleCallback, PostSampleTransform, post_sample_callback, post_sample_transform
+export total_time, effective_time, validate_metadata
+export supports_seed, honors_final_reads, enforces_time_limit
 export ExactSampler, IdentitySampler, MIPSampler, RandomSampler
 
 include("library/drivers/ExactSampler.jl")

--- a/src/interface/attributes.jl
+++ b/src/interface/attributes.jl
@@ -26,14 +26,29 @@ end
 RawSamplerAttribute(key::String) = RawSamplerAttribute{Symbol(key)}()
 
 const _NUMBER_OF_READS_RAW       = "num_reads"
+const _RANDOM_SEED_RAW           = "seed"
 const _FINAL_NUMBER_OF_READS_RAW = "final_num_reads"
 const _POST_SAMPLE_CALLBACK_RAW  = "post_sample_callback"
 const _POST_SAMPLE_TRANSFORM_RAW = "post_sample_transform"
 
 const _RawNumberOfReads       = RawSamplerAttribute{Symbol(_NUMBER_OF_READS_RAW)}
+const _RawRandomSeed          = RawSamplerAttribute{Symbol(_RANDOM_SEED_RAW)}
 const _RawFinalNumberOfReads  = RawSamplerAttribute{Symbol(_FINAL_NUMBER_OF_READS_RAW)}
 const _RawPostSampleCallback  = RawSamplerAttribute{Symbol(_POST_SAMPLE_CALLBACK_RAW)}
 const _RawPostSampleTransform = RawSamplerAttribute{Symbol(_POST_SAMPLE_TRANSFORM_RAW)}
+
+@doc raw"""
+    RandomSeed()
+
+Generic sampler optimizer attribute for a reproducibility seed.
+
+The raw optimizer attribute key is `"seed"`, and the default value is
+`nothing`. Generated optimizers support this typed attribute when the driver
+declares the raw `"seed"` attribute in its [`QUBODrivers.@setup`](@ref) block.
+When a seed is set, QUBODrivers records it under
+`metadata["seeds"]["sampler"]` in the emitted `SampleSet`.
+"""
+struct RandomSeed <: SamplerAttribute end
 
 @doc raw"""
     FinalNumberOfReads()
@@ -133,6 +148,24 @@ backend-specific options before storing them.
 function set_raw_attr! end
 
 @doc raw"""
+    random_seed(sampler)
+
+Return the configured sampler seed, or `nothing` when the sampler does not
+support the standard seed attribute or no seed is configured.
+"""
+function random_seed(sampler::AbstractSampler)
+    attr = _RawRandomSeed()
+
+    try
+        MOI.supports(sampler, attr) || return nothing
+
+        return MOI.get(sampler, attr)
+    catch err
+        _is_unavailable_raw_attr(err, attr) ? nothing : rethrow()
+    end
+end
+
+@doc raw"""
     final_number_of_reads(sampler)
 
 Return the effective final read count for `sampler`.
@@ -193,6 +226,61 @@ function post_sample_transform(sampler::AbstractSampler)::Bool
     return transform::Bool
 end
 
+@doc raw"""
+    total_time(sampleset_or_sampler)
+
+Return `metadata["time"]["total"]`, the wall-clock seconds measured around the
+QUBODrivers sampling pipeline, or `nothing` when it is not available.
+"""
+total_time(sampleset::SampleSet) = _metadata_time(sampleset, "total")
+total_time(sampler::AbstractSampler) = total_time(QUBOTools.solution(sampler))
+
+@doc raw"""
+    effective_time(sampleset_or_sampler)
+
+Return `metadata["time"]["effective"]`, the backend solve/sampling seconds
+reported by the driver, or `nothing` when it is not available.
+"""
+effective_time(sampleset::SampleSet) = _metadata_time(sampleset, "effective")
+effective_time(sampler::AbstractSampler) = effective_time(QUBOTools.solution(sampler))
+
+@doc raw"""
+    supports_seed(sampler_or_type)::Bool
+
+Return whether a sampler advertises support for the standard
+[`RandomSeed`](@ref) attribute.
+"""
+supports_seed(::Type{<:AbstractSampler}) = false
+supports_seed(sampler::AbstractSampler) = supports_seed(typeof(sampler))
+
+@doc raw"""
+    honors_final_reads(sampler_or_type)::Bool
+
+Return whether a sampler uses [`FinalNumberOfReads`](@ref) to control the
+number of samples emitted in the final `SampleSet`.
+"""
+honors_final_reads(::Type{<:AbstractSampler}) = false
+honors_final_reads(sampler::AbstractSampler) = honors_final_reads(typeof(sampler))
+
+@doc raw"""
+    enforces_time_limit(sampler_or_type)::Bool
+
+Return whether a sampler enforces `MOI.TimeLimitSec()` as part of its own
+sampling contract. The default is conservative because many wrappers only store
+or forward the attribute.
+"""
+enforces_time_limit(::Type{<:AbstractSampler}) = false
+enforces_time_limit(sampler::AbstractSampler) = enforces_time_limit(typeof(sampler))
+
+function _metadata_time(sampleset::SampleSet, key::String)
+    metadata = QUBOTools.metadata(sampleset)
+    time = get(metadata, "time", nothing)
+
+    time isa AbstractDict || return nothing
+
+    return get(time, key, nothing)
+end
+
 function _is_unavailable_raw_attr(err, attr::RawSamplerAttribute)
     return err isa MOI.GetAttributeNotAllowed{typeof(attr)}
 end
@@ -207,6 +295,14 @@ function _default_number_of_reads(sampler::AbstractSampler)
     catch err
         _is_unavailable_raw_attr(err, attr) ? nothing : rethrow()
     end
+end
+
+function _validate_random_seed(value)
+    if !(isnothing(value) || (value isa Integer && value >= zero(value)))
+        error("Value for 'RandomSeed' must be a non-negative integer, or 'nothing'")
+    end
+
+    return nothing
 end
 
 function _validate_final_number_of_reads(value)
@@ -226,6 +322,8 @@ function _validate_post_sample_transform(value)
     return nothing
 end
 
+MOIU.map_indices(_, ::RandomSeed, value) = value
+MOIU.map_indices(_, ::_RawRandomSeed, value) = value
 MOIU.map_indices(_, ::FinalNumberOfReads, value) = value
 MOIU.map_indices(_, ::_RawFinalNumberOfReads, value) = value
 MOIU.map_indices(_, ::PostSampleCallback, value) = value

--- a/src/interface/sampler.jl
+++ b/src/interface/sampler.jl
@@ -26,7 +26,8 @@ samples use the same sense and domain as the backend output.
 `MOI.optimize!` calls this method and attaches the returned sample set to the
 optimizer. If the returned metadata does not include a `"time"` dictionary with
 a `"total"` entry, or does not include `"status"`, QUBODrivers fills those
-fields with default values.
+fields with default values. It then validates the benchmarking metadata schema
+and emits a warning, not an error, for missing or malformed fields.
 """
 function sample end
 
@@ -80,6 +81,178 @@ function _sampler_metadata(;
 end
 
 @doc raw"""
+    validate_metadata(sampleset::SampleSet)
+    validate_metadata(metadata::AbstractDict)
+
+Return a list of benchmarking metadata schema violations.
+
+The validator is intentionally non-throwing so driver authors can use it while
+migrating metadata. `MOI.optimize!` calls it after QUBODrivers stamps framework
+metadata and emits a warning when the returned list is not empty.
+"""
+function validate_metadata(sampleset::SampleSet)
+    return validate_metadata(QUBOTools.metadata(sampleset))
+end
+
+function validate_metadata(metadata::AbstractDict)
+    violations = String[]
+
+    _require_string_metadata!(violations, metadata, "metadata", "origin")
+    _require_string_metadata!(violations, metadata, "metadata", "status")
+
+    algorithm = _require_dict_metadata!(violations, metadata, "metadata", "algorithm")
+    if !isnothing(algorithm)
+        _require_string_metadata!(violations, algorithm, "metadata[\"algorithm\"]", "name")
+    end
+
+    backend = _require_dict_metadata!(violations, metadata, "metadata", "backend")
+    if !isnothing(backend)
+        _require_string_metadata!(violations, backend, "metadata[\"backend\"]", "name")
+        _require_backend_version_metadata!(
+            violations,
+            backend,
+            "metadata[\"backend\"]",
+            "version",
+        )
+    end
+
+    reads = _require_dict_metadata!(violations, metadata, "metadata", "reads")
+    if !isnothing(reads)
+        _require_nonnegative_integer_metadata!(
+            violations,
+            reads,
+            "metadata[\"reads\"]",
+            "number_of_reads",
+        )
+        _require_nonnegative_integer_metadata!(
+            violations,
+            reads,
+            "metadata[\"reads\"]",
+            "final_number_of_reads",
+        )
+    end
+
+    seeds = _require_dict_metadata!(violations, metadata, "metadata", "seeds")
+    if !isnothing(seeds)
+        _require_string_keys_metadata!(violations, seeds, "metadata[\"seeds\"]")
+    end
+
+    time = _require_dict_metadata!(violations, metadata, "metadata", "time")
+    if !isnothing(time)
+        _require_nonnegative_real_metadata!(
+            violations,
+            time,
+            "metadata[\"time\"]",
+            "total",
+        )
+        _require_nonnegative_real_metadata!(
+            violations,
+            time,
+            "metadata[\"time\"]",
+            "effective",
+        )
+    end
+
+    return violations
+end
+
+function _has_metadata_key!(violations::Vector{String}, metadata::AbstractDict, path, key)
+    if haskey(metadata, key)
+        return true
+    else
+        push!(violations, "$(path) must contain key \"$(key)\"")
+
+        return false
+    end
+end
+
+function _require_dict_metadata!(violations::Vector{String}, metadata::AbstractDict, path, key)
+    _has_metadata_key!(violations, metadata, path, key) || return nothing
+
+    value = metadata[key]
+
+    if value isa AbstractDict
+        return value
+    else
+        push!(violations, "$(path)[\"$(key)\"] must be a dictionary")
+
+        return nothing
+    end
+end
+
+function _require_string_metadata!(violations::Vector{String}, metadata::AbstractDict, path, key)
+    _has_metadata_key!(violations, metadata, path, key) || return nothing
+
+    value = metadata[key]
+    value isa AbstractString || push!(violations, "$(path)[\"$(key)\"] must be a string")
+
+    return nothing
+end
+
+function _require_backend_version_metadata!(
+    violations::Vector{String},
+    metadata::AbstractDict,
+    path,
+    key,
+)
+    _has_metadata_key!(violations, metadata, path, key) || return nothing
+
+    value = metadata[key]
+    if !(isnothing(value) || value isa VersionNumber || value isa AbstractString)
+        push!(
+            violations,
+            "$(path)[\"$(key)\"] must be a VersionNumber, string, or nothing",
+        )
+    end
+
+    return nothing
+end
+
+function _require_nonnegative_integer_metadata!(
+    violations::Vector{String},
+    metadata::AbstractDict,
+    path,
+    key,
+)
+    _has_metadata_key!(violations, metadata, path, key) || return nothing
+
+    value = metadata[key]
+    if !(value isa Integer && value >= zero(value))
+        push!(violations, "$(path)[\"$(key)\"] must be a non-negative integer")
+    end
+
+    return nothing
+end
+
+function _require_nonnegative_real_metadata!(
+    violations::Vector{String},
+    metadata::AbstractDict,
+    path,
+    key,
+)
+    _has_metadata_key!(violations, metadata, path, key) || return nothing
+
+    value = metadata[key]
+    if !(value isa Real && value >= zero(value))
+        push!(violations, "$(path)[\"$(key)\"] must be a non-negative real number")
+    end
+
+    return nothing
+end
+
+function _require_string_keys_metadata!(
+    violations::Vector{String},
+    metadata::AbstractDict,
+    path,
+)
+    for key in keys(metadata)
+        key isa AbstractString || push!(violations, "$(path) keys must be strings")
+    end
+
+    return nothing
+end
+
+@doc raw"""
     set_model!(sampler::AbstractSampler{T}, model::QUBOTools.Model{VI,T,Int}) where {T}
 
 Store the QUBOTools model backing a sampler.
@@ -115,7 +288,43 @@ function _sample!(sampler::AbstractSampler{T}, sampleset::SampleSet{T}, total_ti
         metadata["status"] = ""
     end
 
+    _record_random_seed_metadata!(sampler, metadata)
+    _warn_metadata_violations(sampleset)
+
     QUBOTools.attach!(sampler, sampleset)
+
+    return nothing
+end
+
+function _record_random_seed_metadata!(
+    sampler::AbstractSampler,
+    metadata::Dict{String,Any},
+)
+    seed = random_seed(sampler)
+
+    isnothing(seed) && return nothing
+
+    seeds = get(metadata, "seeds", nothing)
+    if seeds isa Dict{String,Any}
+        metadata_seeds = seeds
+    elseif seeds isa AbstractDict
+        metadata_seeds = Dict{String,Any}(string(key) => value for (key, value) in seeds)
+    else
+        metadata_seeds = Dict{String,Any}()
+    end
+
+    metadata_seeds["sampler"] = seed
+    metadata["seeds"] = metadata_seeds
+
+    return nothing
+end
+
+function _warn_metadata_violations(sampleset::SampleSet)
+    violations = validate_metadata(sampleset)
+
+    isempty(violations) && return nothing
+
+    @warn "SampleSet metadata does not conform to the QUBODrivers benchmarking schema" violations
 
     return nothing
 end

--- a/src/library/drivers/ExactSampler.jl
+++ b/src/library/drivers/ExactSampler.jl
@@ -22,6 +22,8 @@ QUBODrivers.@setup Optimizer begin
     version = QUBODrivers.__version__()
 end
 
+QUBODrivers.honors_final_reads(::Type{<:Optimizer}) = false
+
 sample_state(i::Integer, n::Integer) = digits(Int, i - 1; base = 2, pad = n)
 
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
@@ -46,6 +48,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         algorithm_name        = "Exact Sampler",
         execution_mode        = "exhaustive_search",
         optimizer_evaluations = m,
+        number_of_reads       = m,
         final_number_of_reads = m,
         status                = "optimal",
         termination_status    = MOI.OPTIMAL,

--- a/src/library/drivers/IdentitySampler.jl
+++ b/src/library/drivers/IdentitySampler.jl
@@ -22,6 +22,8 @@ QUBODrivers.@setup Optimizer begin
     version = QUBODrivers.__version__()
 end
 
+QUBODrivers.honors_final_reads(::Type{<:Optimizer}) = false
+
 function sample_state(sampler::Optimizer{T}, n::Integer) where {T}
     ψ = Vector{Int}(undef, n)
 
@@ -59,6 +61,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         algorithm_name        = "Identity Sampler",
         execution_mode        = "warm_start",
         optimizer_evaluations = 1,
+        number_of_reads       = 1,
         final_number_of_reads = 1,
         status                = "locally_solved",
         termination_status    = MOI.LOCALLY_SOLVED,

--- a/src/library/drivers/MIPSampler.jl
+++ b/src/library/drivers/MIPSampler.jl
@@ -40,6 +40,8 @@ QUBODrivers.@setup Optimizer begin
     end
 end
 
+QUBODrivers.honors_final_reads(::Type{<:Optimizer}) = false
+
 @doc raw"""
     MIPOptimizer()
 
@@ -278,6 +280,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         backend_version       = _backend_attribute(backend, MOI.SolverVersion()),
         execution_mode        = "mip_solve",
         optimizer_evaluations = 1,
+        number_of_reads       = 1,
         final_number_of_reads = 1,
         status                = string(termination_status),
         termination_status    = termination_status,

--- a/src/library/drivers/RandomSampler.jl
+++ b/src/library/drivers/RandomSampler.jl
@@ -17,7 +17,8 @@ evaluates their objective values with QUBOTools, and returns the final sampled
 states.
 
 ## Attributes
-- `RandomSeed`, `"seed"`: Random seed to initialize the random number generator.
+- `QUBODrivers.RandomSeed`, `"seed"`: Random seed to initialize the random
+  number generator.
 - `NumberOfReads`, `"num_reads"`: Default final read count.
 - `QUBODrivers.FinalNumberOfReads`, `"final_num_reads"`: Number of random
   states emitted in the returned sample set. If unset, this defaults to
@@ -28,11 +29,13 @@ QUBODrivers.@setup Optimizer begin
     name       = "Random Sampler"
     version    = QUBODrivers.__version__()
     attributes = begin
-        RandomSeed["seed"]::Union{Integer,Nothing} = nothing
+        "seed"::Union{Integer,Nothing}             = nothing
         NumberOfReads["num_reads"]::Integer        = 1_000
         RandomGenerator["rng"]::AbstractRNG        = Random.GLOBAL_RNG
     end
 end
+
+QUBODrivers.honors_final_reads(::Type{<:Optimizer}) = true
 
 sample_state(rng::AbstractRNG, n::Integer) = rand(rng, (0, 1), n)
 
@@ -43,7 +46,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
     # Retrieve Attributes
     num_reads       = MOI.get(sampler, NumberOfReads())
     final_num_reads = MOI.get(sampler, QUBODrivers.FinalNumberOfReads())
-    seed            = MOI.get(sampler, RandomSeed())
+    seed            = MOI.get(sampler, QUBODrivers.RandomSeed())
     rng             = MOI.get(sampler, RandomGenerator())
 
     # Validate Input
@@ -72,7 +75,6 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         optimizer_evaluations = final_num_reads,
         number_of_reads       = final_num_reads,
         final_number_of_reads = final_num_reads,
-        seeds                 = Dict{String,Any}("sampler" => seed),
         status                = "locally_solved",
         termination_status    = MOI.LOCALLY_SOLVED,
     )

--- a/src/library/drivers/RandomSampler.jl
+++ b/src/library/drivers/RandomSampler.jl
@@ -29,7 +29,7 @@ QUBODrivers.@setup Optimizer begin
     name       = "Random Sampler"
     version    = QUBODrivers.__version__()
     attributes = begin
-        "seed"::Union{Integer,Nothing}             = nothing
+        RandomSeed["seed"]::Union{Integer,Nothing} = nothing
         NumberOfReads["num_reads"]::Integer        = 1_000
         RandomGenerator["rng"]::AbstractRNG        = Random.GLOBAL_RNG
     end

--- a/src/library/sampler/wrappers/moi.jl
+++ b/src/library/sampler/wrappers/moi.jl
@@ -516,7 +516,7 @@ function MOI.get(sampler::AbstractSampler{T}, ov::MOI.ObjectiveValue) where {T}
 end
 
 function MOI.get(sampler::AbstractSampler{T}, ::MOI.SolveTimeSec) where {T}
-    return QUBOTools.effective_time(QUBOTools.solution(sampler))
+    return effective_time(sampler)
 end
 
 function MOI.get(sampler::AbstractSampler{T}, vp::MOI.VariablePrimal, vi::VI) where {T}

--- a/src/library/setup/quote.jl
+++ b/src/library/setup/quote.jl
@@ -261,8 +261,42 @@ end
 
 function __setup_quote_qubodrivers_attrs(spec::_SamplerSpec)
     Optimizer = esc(spec.id)
+    random_seed_trait = if any(attr -> attr.raw_attr == _RANDOM_SEED_RAW, spec.attributes)
+        quote
+            QUBODrivers.supports_seed(::Type{<:$(Optimizer)}) = true
+        end
+    else
+        quote end
+    end
 
     return quote
+        $(random_seed_trait)
+
+        # QUBODrivers.RandomSeed - get
+        function MOI.get(sampler::$(Optimizer), ::QUBODrivers.RandomSeed)
+            return QUBODrivers.random_seed(sampler)
+        end
+
+        # QUBODrivers.RandomSeed - set
+        function MOI.set(sampler::$(Optimizer), ::QUBODrivers.RandomSeed, value)
+            MOI.supports(sampler, QUBODrivers.RandomSeed()) ||
+                error("'QUBODrivers.RandomSeed' is not supported by this sampler")
+
+            return MOI.set(sampler, QUBODrivers._RawRandomSeed(), value)
+        end
+
+        function MOI.set(sampler::$(Optimizer), attr::QUBODrivers._RawRandomSeed, value)
+            QUBODrivers._validate_random_seed(value)
+            QUBODrivers.set_raw_attr!(sampler, attr, value)
+
+            return nothing
+        end
+
+        # QUBODrivers.RandomSeed - support
+        function MOI.supports(sampler::$(Optimizer), ::QUBODrivers.RandomSeed)
+            return MOI.supports(sampler, QUBODrivers._RawRandomSeed())
+        end
+
         # QUBODrivers.FinalNumberOfReads - get
         function MOI.get(sampler::$(Optimizer), ::QUBODrivers.FinalNumberOfReads)
             return QUBODrivers.final_number_of_reads(sampler)

--- a/test/drivers/exact_sampler.jl
+++ b/test/drivers/exact_sampler.jl
@@ -11,6 +11,7 @@ function _test_exact_sampler_metadata_schema()
             _solution_metadata(model);
             algorithm_name        = "Exact Sampler",
             execution_mode        = "exhaustive_search",
+            number_of_reads       = 2,
             optimizer_evaluations = 2,
             final_number_of_reads = 2,
             status                = "optimal",

--- a/test/drivers/identity_sampler.jl
+++ b/test/drivers/identity_sampler.jl
@@ -16,6 +16,7 @@ function _test_identity_sampler_metadata_schema()
             _solution_metadata(model);
             algorithm_name        = "Identity Sampler",
             execution_mode        = "warm_start",
+            number_of_reads       = 1,
             optimizer_evaluations = 1,
             final_number_of_reads = 1,
             status                = "locally_solved",

--- a/test/drivers/mip_sampler.jl
+++ b/test/drivers/mip_sampler.jl
@@ -362,6 +362,7 @@ function _test_mip_sampler_optional_attribute_and_metadata_fallbacks()
             metadata;
             algorithm_name        = "MIP Sampler",
             execution_mode        = "mip_solve",
+            number_of_reads       = 1,
             optimizer_evaluations = 1,
             final_number_of_reads = 1,
             status                = "OPTIMAL",

--- a/test/drivers/random_sampler.jl
+++ b/test/drivers/random_sampler.jl
@@ -123,8 +123,14 @@ function _test_random_sampler_final_number_of_reads_sampling()
         MOI.optimize!(default_model)
 
         default_metadata = _solution_metadata(default_model)
+        default_solution = _random_solution(default_model)
 
         @test _random_total_reads(default_model) == 7
+        @test default_metadata["seeds"]["sampler"] == 1
+        @test isempty(QUBODrivers.validate_metadata(default_solution))
+        @test QUBODrivers.total_time(default_solution) isa Real
+        @test QUBODrivers.effective_time(default_solution) isa Real
+        @test MOI.get(default_model, MOI.SolveTimeSec()) == QUBODrivers.effective_time(default_solution)
         @test !haskey(default_metadata, "postprocess")
         _assert_sampler_metadata_schema(
             default_metadata;
@@ -144,6 +150,7 @@ function _test_random_sampler_final_number_of_reads_sampling()
         override_metadata = _solution_metadata(override_model)
 
         @test _random_total_reads(override_model) == 3
+        @test override_metadata["seeds"]["sampler"] == 1
         _assert_sampler_metadata_schema(
             override_metadata;
             algorithm_name        = "Random Sampler",

--- a/test/drivers/sampler_bundle.jl
+++ b/test/drivers/sampler_bundle.jl
@@ -9,11 +9,13 @@ function _assert_sampler_metadata_schema(
     algorithm_name::String,
     execution_mode::String,
     final_number_of_reads::Integer,
-    number_of_reads = nothing,
+    number_of_reads::Integer,
     optimizer_evaluations = nothing,
     status::String,
     termination_status,
 )
+    @test isempty(QUBODrivers.validate_metadata(metadata))
+    @test metadata["origin"] isa String
     @test metadata["algorithm"]["name"] == algorithm_name
     @test haskey(metadata["backend"], "name")
     @test haskey(metadata["backend"], "version")
@@ -23,6 +25,8 @@ function _assert_sampler_metadata_schema(
     @test metadata["reads"]["number_of_reads"] == number_of_reads
     @test metadata["reads"]["final_number_of_reads"] == final_number_of_reads
     @test haskey(metadata, "seeds")
+    @test metadata["time"]["total"] isa Real
+    @test metadata["time"]["effective"] isa Real
     @test metadata["status"] == status
     @test metadata["termination_status"] == termination_status
 

--- a/test/setup/setup.jl
+++ b/test/setup/setup.jl
@@ -55,20 +55,30 @@ function test_random_seed_attribute_defaults()
 
         @test QUBODrivers.supports_seed(sampler)
         @test QUBODrivers.supports_seed(RandomSampler.Optimizer)
+        @test isdefined(RandomSampler, :RandomSeed)
         @test MOI.supports(sampler, QUBODrivers.RandomSeed())
+        @test MOI.supports(sampler, RandomSampler.RandomSeed())
         @test MOI.supports(sampler, MOI.RawOptimizerAttribute("seed"))
         @test MOI.get(sampler, QUBODrivers.RandomSeed()) === nothing
+        @test MOI.get(sampler, RandomSampler.RandomSeed()) === nothing
         @test QUBODrivers.random_seed(sampler) === nothing
+
+        MOI.set(sampler, RandomSampler.RandomSeed(), 13)
+        @test MOI.get(sampler, RandomSampler.RandomSeed()) == 13
+        @test MOI.get(sampler, QUBODrivers.RandomSeed()) == 13
 
         MOI.set(sampler, QUBODrivers.RandomSeed(), 11)
         @test MOI.get(sampler, QUBODrivers.RandomSeed()) == 11
+        @test MOI.get(sampler, RandomSampler.RandomSeed()) == 11
         @test MOI.get(sampler, MOI.RawOptimizerAttribute("seed")) == 11
         @test QUBODrivers.random_seed(sampler) == 11
 
         MOI.set(sampler, MOI.RawOptimizerAttribute("seed"), nothing)
         @test MOI.get(sampler, QUBODrivers.RandomSeed()) === nothing
+        @test MOI.get(sampler, RandomSampler.RandomSeed()) === nothing
 
         @test_throws ErrorException MOI.set(sampler, QUBODrivers.RandomSeed(), -1)
+        @test_throws ErrorException MOI.set(sampler, RandomSampler.RandomSeed(), -1)
         @test_throws ErrorException MOI.set(sampler, MOI.RawOptimizerAttribute("seed"), -1)
 
         exact_sampler = ExactSampler.Optimizer()

--- a/test/setup/setup.jl
+++ b/test/setup/setup.jl
@@ -3,7 +3,9 @@ function test_setup_macro()
         test_project_version()
         test_project_compat()
         test_setup_spec_parser()
+        test_random_seed_attribute_defaults()
         test_final_number_of_reads_fallbacks()
+        test_capability_traits()
         test_post_sample_attribute_defaults()
         test_post_sample_callback_optimize_fallbacks()
     end
@@ -47,6 +49,37 @@ function test_project_compat()
     return nothing
 end
 
+function test_random_seed_attribute_defaults()
+    @testset "→ RandomSeed attribute" begin
+        sampler = RandomSampler.Optimizer()
+
+        @test QUBODrivers.supports_seed(sampler)
+        @test QUBODrivers.supports_seed(RandomSampler.Optimizer)
+        @test MOI.supports(sampler, QUBODrivers.RandomSeed())
+        @test MOI.supports(sampler, MOI.RawOptimizerAttribute("seed"))
+        @test MOI.get(sampler, QUBODrivers.RandomSeed()) === nothing
+        @test QUBODrivers.random_seed(sampler) === nothing
+
+        MOI.set(sampler, QUBODrivers.RandomSeed(), 11)
+        @test MOI.get(sampler, QUBODrivers.RandomSeed()) == 11
+        @test MOI.get(sampler, MOI.RawOptimizerAttribute("seed")) == 11
+        @test QUBODrivers.random_seed(sampler) == 11
+
+        MOI.set(sampler, MOI.RawOptimizerAttribute("seed"), nothing)
+        @test MOI.get(sampler, QUBODrivers.RandomSeed()) === nothing
+
+        @test_throws ErrorException MOI.set(sampler, QUBODrivers.RandomSeed(), -1)
+        @test_throws ErrorException MOI.set(sampler, MOI.RawOptimizerAttribute("seed"), -1)
+
+        exact_sampler = ExactSampler.Optimizer()
+        @test !QUBODrivers.supports_seed(exact_sampler)
+        @test !MOI.supports(exact_sampler, QUBODrivers.RandomSeed())
+        @test QUBODrivers.random_seed(exact_sampler) === nothing
+    end
+
+    return nothing
+end
+
 function test_post_sample_attribute_defaults()
     @testset "→ Post-sample callback attributes" begin
         sampler = RandomSampler.Optimizer()
@@ -75,6 +108,27 @@ function test_post_sample_attribute_defaults()
             QUBODrivers.PostSampleTransform(),
             "true",
         )
+    end
+
+    return nothing
+end
+
+function test_capability_traits()
+    @testset "→ Capability traits" begin
+        @test QUBODrivers.supports_seed(RandomSampler.Optimizer)
+        @test !QUBODrivers.supports_seed(ExactSampler.Optimizer)
+        @test !QUBODrivers.supports_seed(IdentitySampler.Optimizer)
+        @test !QUBODrivers.supports_seed(MIPSampler.Optimizer)
+
+        @test QUBODrivers.honors_final_reads(RandomSampler.Optimizer)
+        @test !QUBODrivers.honors_final_reads(ExactSampler.Optimizer)
+        @test !QUBODrivers.honors_final_reads(IdentitySampler.Optimizer)
+        @test !QUBODrivers.honors_final_reads(MIPSampler.Optimizer)
+
+        @test !QUBODrivers.enforces_time_limit(RandomSampler.Optimizer)
+        @test !QUBODrivers.enforces_time_limit(ExactSampler.Optimizer)
+        @test !QUBODrivers.enforces_time_limit(IdentitySampler.Optimizer)
+        @test !QUBODrivers.enforces_time_limit(MIPSampler.Optimizer)
     end
 
     return nothing
@@ -115,6 +169,7 @@ function _custom_sampleset()
         final_number_of_reads = 1,
         status                = "locally_solved",
     )
+    metadata["time"] = Dict{String,Any}("effective" => 0.0)
     samples = [QUBOTools.Sample{Float64,Int}([0], 0.0)]
 
     return QUBOTools.SampleSet{Float64,Int}(samples, metadata; sense = :min, domain = :bool)


### PR DESCRIPTION
Summary
- Add a normative benchmarking metadata schema with warning-only validation through `QUBODrivers.validate_metadata`.
- Add the standard `QUBODrivers.RandomSeed` attribute, automatic sampler seed recording, effective/total time accessors, and conservative capability traits.
- Update ExactSampler, IdentitySampler, MIPSampler, and RandomSampler metadata to validate cleanly, with tests for the new public API.
- Add and link the metadata schema docs page, including `MOI.SolveTimeSec()` effective-time semantics.

Tests
- `julia --project=. -e 'using QUBODrivers; using QUBODrivers: MOI, QUBOTools; s = RandomSampler.Optimizer(); @assert QUBODrivers.supports_seed(s); MOI.set(s, QUBODrivers.RandomSeed(), 3); @assert QUBODrivers.random_seed(s) == 3; @assert QUBODrivers.honors_final_reads(s); println("smoke ok")'`
- `julia --project=. -e 'import Pkg; Pkg.test()'` -> 938 tests passed
- `julia --project=docs -e 'pushfirst!(LOAD_PATH, pwd()); push!(ARGS, "--skip-deploy"); include("docs/make.jl")'`

Notes
- MQLib.jl external compatibility tests were not run locally.

Refs #49
