### PR TITLE
Add benchmark conformance checks to QUBODrivers.test

### DIFF
--- a/docs/src/manual/5-tests.md
+++ b/docs/src/manual/5-tests.md
@@ -46,6 +46,31 @@ checks:
 QUBODrivers.test(MySampler.Optimizer; examples = false)
 ```
 
+Benchmark conformance checks are also enabled by default. They exercise a tiny
+three-variable model and verify that benchmark-facing metadata, timing, reads,
+seed, time-limit, and termination-status behavior matches QUBODrivers' public
+schema and traits.
+
+Disable the full conformance group for drivers that are not benchmark-ready yet:
+
+```julia
+QUBODrivers.test(MySampler.Optimizer; benchmark_conformance = false)
+```
+
+You can also disable individual groups:
+
+```julia
+QUBODrivers.test(
+    MySampler.Optimizer;
+    metadata_conformance = false,
+    timing_sanity = false,
+    determinism = false,
+    reads_semantics = false,
+    time_limit_acceptance = false,
+    termination_status = false,
+)
+```
+
 ## What the Suite Expects
 
 A sampler should:
@@ -57,6 +82,26 @@ A sampler should:
 - return at least one result for solvable test models;
 - expose result count, objective values, variable primals, solve time, and
   status through standard MOI attributes.
+- return benchmark-ready metadata accepted by
+  `QUBODrivers.validate_metadata`;
+- stamp positive `metadata["time"]["total"]` and
+  `metadata["time"]["effective"]`, with effective time no larger than total
+  time;
+- accept `QUBODrivers.FinalNumberOfReads()` and either honor it for the final
+  emitted `SampleSet` length or report `honors_final_reads(optimizer) == false`;
+- accept `MOI.TimeLimitSec()` without error, and keep total time within a
+  generous smoke-test slack if `enforces_time_limit(optimizer)` is true;
+- return a termination status in `OPTIMAL`, `LOCALLY_SOLVED`, `TIME_LIMIT`,
+  `ITERATION_LIMIT`, or `OTHER_LIMIT`;
+- produce identical sample states and values for repeated same-seed runs when
+  `supports_seed(optimizer)` is true.
+
+The benchmark conformance assertions are intentionally limited to the metadata
+schema documented on the [Metadata Schema](@ref) page and the public capability
+traits, including [`QUBODrivers.validate_metadata`](@ref),
+[`QUBODrivers.supports_seed`](@ref),
+[`QUBODrivers.honors_final_reads`](@ref), and
+[`QUBODrivers.enforces_time_limit`](@ref).
 
 ```@docs
 QUBODrivers.test

--- a/ext/QUBODrivers_Test_Ext/QUBODrivers_Test_Ext.jl
+++ b/ext/QUBODrivers_Test_Ext/QUBODrivers_Test_Ext.jl
@@ -17,22 +17,34 @@ const Spin   = QUBODrivers.Spin
 include("interface/fixed.jl")
 include("interface/moi.jl")
 include("interface/automatic.jl")
+include("interface/benchmark_conformance.jl")
 
 # Example Tests
 include("examples/examples.jl")
 
-function QUBODrivers.test(::Type{S}; examples::Bool = true) where {S<:QUBODrivers.AbstractSampler}
-    QUBODrivers.test(identity, S; examples)
-
-    return nothing
-end
-
 function QUBODrivers.test(
-    config!::Function,
     ::Type{S};
     examples::Bool = true,
+    benchmark_conformance::Bool = true,
+    metadata_conformance::Bool = benchmark_conformance,
+    timing_sanity::Bool = benchmark_conformance,
+    determinism = benchmark_conformance ? :auto : false,
+    reads_semantics::Bool = benchmark_conformance,
+    time_limit_acceptance::Bool = benchmark_conformance,
+    termination_status::Bool = benchmark_conformance,
 ) where {S<:QUBODrivers.AbstractSampler}
-    QUBODrivers.test(config!, S{Float64}; examples)
+    QUBODrivers.test(
+        identity,
+        S;
+        examples,
+        benchmark_conformance,
+        metadata_conformance,
+        timing_sanity,
+        determinism,
+        reads_semantics,
+        time_limit_acceptance,
+        termination_status,
+    )
 
     return nothing
 end
@@ -41,6 +53,41 @@ function QUBODrivers.test(
     config!::Function,
     ::Type{S};
     examples::Bool = true,
+    benchmark_conformance::Bool = true,
+    metadata_conformance::Bool = benchmark_conformance,
+    timing_sanity::Bool = benchmark_conformance,
+    determinism = benchmark_conformance ? :auto : false,
+    reads_semantics::Bool = benchmark_conformance,
+    time_limit_acceptance::Bool = benchmark_conformance,
+    termination_status::Bool = benchmark_conformance,
+) where {S<:QUBODrivers.AbstractSampler}
+    QUBODrivers.test(
+        config!,
+        S{Float64};
+        examples,
+        benchmark_conformance,
+        metadata_conformance,
+        timing_sanity,
+        determinism,
+        reads_semantics,
+        time_limit_acceptance,
+        termination_status,
+    )
+
+    return nothing
+end
+
+function QUBODrivers.test(
+    config!::Function,
+    ::Type{S};
+    examples::Bool = true,
+    benchmark_conformance::Bool = true,
+    metadata_conformance::Bool = benchmark_conformance,
+    timing_sanity::Bool = benchmark_conformance,
+    determinism = benchmark_conformance ? :auto : false,
+    reads_semantics::Bool = benchmark_conformance,
+    time_limit_acceptance::Bool = benchmark_conformance,
+    termination_status::Bool = benchmark_conformance,
 ) where {T,S<:QUBODrivers.AbstractSampler{T}}
     sampler = S()
 
@@ -55,6 +102,25 @@ function QUBODrivers.test(
 
         if examples
             _test_examples(config!, S)
+        end
+
+        if benchmark_conformance ||
+           metadata_conformance ||
+           timing_sanity ||
+           _run_seed_determinism(determinism, S) ||
+           reads_semantics ||
+           time_limit_acceptance ||
+           termination_status
+            _test_benchmark_conformance(
+                config!,
+                S;
+                metadata_conformance,
+                timing_sanity,
+                determinism,
+                reads_semantics,
+                time_limit_acceptance,
+                termination_status,
+            )
         end
     end
 

--- a/ext/QUBODrivers_Test_Ext/interface/benchmark_conformance.jl
+++ b/ext/QUBODrivers_Test_Ext/interface/benchmark_conformance.jl
@@ -1,0 +1,214 @@
+const _BENCHMARK_CONFORMANCE_FINAL_READS = 5
+const _BENCHMARK_CONFORMANCE_TIME_LIMIT = 1.0
+const _BENCHMARK_CONFORMANCE_TIME_LIMIT_SLACK = 5.0
+const _BENCHMARK_CONFORMANCE_TIME_TOL = 1.0e-6
+const _BENCHMARK_ALLOWED_TERMINATION_STATUSES = Set([
+    MOI.OPTIMAL,
+    MOI.LOCALLY_SOLVED,
+    MOI.TIME_LIMIT,
+    MOI.ITERATION_LIMIT,
+    MOI.OTHER_LIMIT,
+])
+
+function _run_seed_determinism(determinism, ::Type{S}) where {S<:QUBODrivers.AbstractSampler}
+    if determinism === :auto
+        return QUBODrivers.supports_seed(S)
+    elseif determinism isa Bool
+        return determinism
+    else
+        error("`determinism` must be `:auto`, `true`, or `false`")
+    end
+end
+
+function _benchmark_conformance_model(
+    config!::Function,
+    sampler::Type{S};
+    final_number_of_reads = _BENCHMARK_CONFORMANCE_FINAL_READS,
+    seed = nothing,
+    time_limit = nothing,
+) where {T,S<:QUBODrivers.AbstractSampler{T}}
+    model = MOI.instantiate(sampler; with_bridge_type = T)
+
+    Q = T[
+        1 -2 3
+        0 -1 -2
+        0 0 2
+    ]
+    x, _ = MOI.add_constrained_variables(model, fill(MOI.ZeroOne(), 3))
+
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(model, MOI.ObjectiveFunction{SQF{T}}(), x' * Q * x)
+
+    config!(model)
+
+    if !isnothing(final_number_of_reads)
+        MOI.set(model, QUBODrivers.FinalNumberOfReads(), final_number_of_reads)
+    end
+
+    if !isnothing(seed)
+        MOI.set(model, QUBODrivers.RandomSeed(), seed)
+    end
+
+    if !isnothing(time_limit)
+        MOI.set(model, MOI.TimeLimitSec(), time_limit)
+    end
+
+    return model
+end
+
+function _benchmark_conformance_solution(model)
+    raw = MOI.get(model, MOI.RawSolver())
+
+    return QUBOTools.solution(raw)
+end
+
+function _optimize_benchmark_conformance_model(args...; kwargs...)
+    model = _benchmark_conformance_model(args...; kwargs...)
+
+    MOI.optimize!(model)
+
+    return model, _benchmark_conformance_solution(model)
+end
+
+function _sampleset_states_and_values(sampleset)
+    return [(copy(QUBOTools.state(sample)), QUBOTools.value(sample)) for sample in sampleset]
+end
+
+function _test_benchmark_metadata_conformance(config!::Function, sampler::Type{S}) where {S}
+    Test.@testset "Metadata Conformance" begin
+        _, sampleset = _optimize_benchmark_conformance_model(config!, sampler)
+        violations = QUBODrivers.validate_metadata(sampleset)
+
+        Test.@test isempty(violations)
+    end
+
+    return nothing
+end
+
+function _test_benchmark_timing_sanity(config!::Function, sampler::Type{S}) where {S}
+    Test.@testset "Timing Sanity" begin
+        model, sampleset = _optimize_benchmark_conformance_model(config!, sampler)
+        metadata = QUBOTools.metadata(sampleset)
+        time = get(metadata, "time", nothing)
+
+        Test.@test time isa AbstractDict
+
+        if time isa AbstractDict
+            total = get(time, "total", nothing)
+            effective = get(time, "effective", nothing)
+
+            Test.@test total isa Real
+            Test.@test effective isa Real
+
+            if total isa Real && effective isa Real
+                Test.@test total > 0
+                Test.@test effective > 0
+                Test.@test effective <= total * (1 + _BENCHMARK_CONFORMANCE_TIME_TOL)
+            end
+        end
+
+        Test.@test MOI.get(model, MOI.SolveTimeSec()) >= 0
+    end
+
+    return nothing
+end
+
+function _test_benchmark_seed_determinism(config!::Function, sampler::Type{S}) where {S}
+    Test.@testset "Seed Determinism" begin
+        first_model, first_sampleset =
+            _optimize_benchmark_conformance_model(config!, sampler; seed = 1)
+        second_model, second_sampleset =
+            _optimize_benchmark_conformance_model(config!, sampler; seed = 1)
+
+        Test.@test MOI.get(first_model, MOI.ResultCount()) ==
+                   MOI.get(second_model, MOI.ResultCount())
+        Test.@test _sampleset_states_and_values(first_sampleset) ==
+                   _sampleset_states_and_values(second_sampleset)
+    end
+
+    return nothing
+end
+
+function _test_benchmark_reads_semantics(config!::Function, sampler::Type{S}) where {S}
+    Test.@testset "Reads Semantics" begin
+        k = _BENCHMARK_CONFORMANCE_FINAL_READS
+        _, sampleset =
+            _optimize_benchmark_conformance_model(config!, sampler; final_number_of_reads = k)
+
+        Test.@test !QUBODrivers.honors_final_reads(S) || length(sampleset) <= k
+    end
+
+    return nothing
+end
+
+function _test_benchmark_time_limit_acceptance(config!::Function, sampler::Type{S}) where {S}
+    Test.@testset "Time Limit Acceptance" begin
+        limit = _BENCHMARK_CONFORMANCE_TIME_LIMIT
+        model = _benchmark_conformance_model(
+            config!,
+            sampler;
+            final_number_of_reads = _BENCHMARK_CONFORMANCE_FINAL_READS,
+        )
+
+        Test.@test MOI.set(model, MOI.TimeLimitSec(), limit) === nothing
+
+        if QUBODrivers.enforces_time_limit(S)
+            MOI.optimize!(model)
+            sampleset = _benchmark_conformance_solution(model)
+            total = QUBOTools.metadata(sampleset)["time"]["total"]
+
+            Test.@test total <= limit * _BENCHMARK_CONFORMANCE_TIME_LIMIT_SLACK
+        end
+    end
+
+    return nothing
+end
+
+function _test_benchmark_termination_status(config!::Function, sampler::Type{S}) where {S}
+    Test.@testset "Termination Status" begin
+        model, _ = _optimize_benchmark_conformance_model(config!, sampler)
+
+        Test.@test MOI.get(model, MOI.TerminationStatus()) in _BENCHMARK_ALLOWED_TERMINATION_STATUSES
+    end
+
+    return nothing
+end
+
+function _test_benchmark_conformance(
+    config!::Function,
+    sampler::Type{S};
+    metadata_conformance::Bool,
+    timing_sanity::Bool,
+    determinism,
+    reads_semantics::Bool,
+    time_limit_acceptance::Bool,
+    termination_status::Bool,
+) where {S<:QUBODrivers.AbstractSampler}
+    Test.@testset "→ Benchmark Conformance" begin
+        if metadata_conformance
+            _test_benchmark_metadata_conformance(config!, sampler)
+        end
+
+        if timing_sanity
+            _test_benchmark_timing_sanity(config!, sampler)
+        end
+
+        if _run_seed_determinism(determinism, sampler)
+            _test_benchmark_seed_determinism(config!, sampler)
+        end
+
+        if reads_semantics
+            _test_benchmark_reads_semantics(config!, sampler)
+        end
+
+        if time_limit_acceptance
+            _test_benchmark_time_limit_acceptance(config!, sampler)
+        end
+
+        if termination_status
+            _test_benchmark_termination_status(config!, sampler)
+        end
+    end
+
+    return nothing
+end

--- a/src/interface/test.jl
+++ b/src/interface/test.jl
@@ -1,11 +1,19 @@
 @doc raw"""
-    test(optimizer::Type{S}; examples::Bool=true) where {S<:AbstractSampler}
-    test(config!::Function, optimizer::Type{S}; examples::Bool=true) where {S<:AbstractSampler}
+    test(optimizer::Type{S}; examples::Bool=true, kwargs...) where {S<:AbstractSampler}
+    test(config!::Function, optimizer::Type{S}; examples::Bool=true, kwargs...) where {S<:AbstractSampler}
 
 Run QUBODrivers' interface and example test suite for a sampler implementation.
 
 These methods are implemented by the `QUBODrivers_Test_Ext` package extension and
 become available when `Test` is loaded in the active environment. The core
 package does not depend on `Test` directly.
+
+Benchmark conformance checks are enabled by default. Pass
+`benchmark_conformance=false` to disable all benchmark conformance checks, or
+disable individual groups with `metadata_conformance=false`,
+`timing_sanity=false`, `determinism=false`, `reads_semantics=false`,
+`time_limit_acceptance=false`, or `termination_status=false`. The default
+`determinism=:auto` runs seed determinism only for samplers whose
+[`supports_seed`](@ref) trait is true.
 """
 function test end


### PR DESCRIPTION
## Summary

- Add a default-on `Benchmark Conformance` group to `QUBODrivers.test`.
- Add per-check opt-outs for metadata conformance, timing sanity, seed determinism, read semantics, time-limit acceptance, and termination status.
- Document the new checks and keyword controls on the test-suite page.

## Assertions

- Metadata: `QUBODrivers.validate_metadata(sampleset)` returns no violations.
- Timing: `metadata["time"]["total"]` and `metadata["time"]["effective"]` are positive, and effective time is no larger than total time within tolerance.
- Seed determinism: when `supports_seed(optimizer)` is true, two same-model same-seed runs emit identical sample states and values.
- Reads: after setting `FinalNumberOfReads`, the emitted `SampleSet` length is no larger than the requested final read count, unless `honors_final_reads(optimizer)` is false.
- Time limit: `MOI.TimeLimitSec()` is accepted without error, and samplers that report `enforces_time_limit(optimizer)` keep total time within a generous smoke-test slack.
- Termination: `MOI.TerminationStatus()` is one of `OPTIMAL`, `LOCALLY_SOLVED`, `TIME_LIMIT`, `ITERATION_LIMIT`, or `OTHER_LIMIT`.

## Tests

- `julia --project=. -e 'using Pkg; Pkg.test()'` passed: 992 tests.
- `julia --project=. -e 'using Test, QUBODrivers; @testset "conformance opt outs" begin QUBODrivers.test(QUBODrivers.RandomSampler.Optimizer; examples=false, benchmark_conformance=false); QUBODrivers.test(QUBODrivers.RandomSampler.Optimizer; examples=false, metadata_conformance=false, timing_sanity=false, determinism=false, reads_semantics=false, time_limit_acceptance=false, termination_status=false) end'` passed: 206 tests.
- `julia --project=docs docs/make.jl --skip-deploy` passed.

## Notes

- The unchanged external-driver failure-list checkpoint from issue 50 has not been run in this local pass, so this PR references the issue rather than closing it.

Refs #50
