### PR TITLE
Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## v0.6.1 - 2026-06-11
+
+### Added / Changed / Maintenance
+
+- Add the benchmark metadata contract used by driver release-wave
+  conformance: `QUBODrivers.RandomSeed`, `validate_metadata`,
+  `total_time`, `effective_time`, and conservative capability traits.
+- Update ExactSampler, IdentitySampler, MIPSampler, and RandomSampler to
+  validate against the benchmark metadata schema.
+- Add default-on benchmark conformance checks to `QUBODrivers.test`,
+  including metadata, timing, seed determinism, read semantics, time-limit
+  acceptance, and termination-status assertions.
+- Document the metadata schema, seed/read/time-limit semantics, and the new
+  test-suite conformance controls.
+
 ## v0.6.0 - 2026-06-08
 
 ### Breaking changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBODrivers"
 uuid = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "AndradeTiago <tiago.andrade@psr-inc.com>", "joaquimg <joaquim@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"


### PR DESCRIPTION
## Summary

- Bump QUBODrivers to v0.6.1.
- Add v0.6.1 changelog notes for the benchmark metadata API from #51 and the conformance test suite from #52.

## Release reason

- MQLib.jl needs a registered QUBODrivers release that contains `QUBODrivers.RandomSeed`, `validate_metadata`, `total_time`, `effective_time`, capability traits, and the `benchmark_conformance` test controls before its issue-26 PR can constrain compat to a released API.

## Tests

- `julia +release --project=. -e 'using Pkg; Pkg.test()'` passed, 992/992.
- `julia +release --project=docs docs/make.jl --skip-deploy` passed.
- `git diff --check` passed.
