### PR TITLE
ci: harden TagBot permissions

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -12,7 +12,7 @@ permissions:
   checks: read
   contents: write
   deployments: read
-  issues: read
+  issues: write
   discussions: read
   packages: read
   pages: read


### PR DESCRIPTION
Summary

- Harden TagBot workflow permissions so tag/release writes and manual-intervention issue creation do not depend on repository default token settings.
- Preserve the existing TagBot SSH configuration where present.

Validation

- git diff --check

Notes

- This PR does not change package code or release metadata.
