### PR TITLE
[codex] docs: add external sampler registration workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/external-sampler-package.yml
+++ b/.github/ISSUE_TEMPLATE/external-sampler-package.yml
@@ -1,0 +1,60 @@
+name: Register external sampler package
+description: Request a QUBODrivers docs entry for an external sampler package.
+title: "[docs] Register external sampler: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when a public JuliaQUBO or SECQUOIA sampler package
+        should be listed in the external sampler package table.
+  - type: input
+    id: package_url
+    attributes:
+      label: Package repository URL
+      description: Link to the sampler package repository.
+      placeholder: https://github.com/JuliaQUBO/Package.jl
+    validations:
+      required: true
+  - type: input
+    id: solver_symbol
+    attributes:
+      label: Solver type
+      description: Public optimizer type users should pass to JuMP or MOI.
+      placeholder: Package.Optimizer
+    validations:
+      required: true
+  - type: input
+    id: source_path
+    attributes:
+      label: Source file path
+      description: Repository path that defines the public optimizer.
+      placeholder: src/Package.jl
+    validations:
+      required: true
+  - type: dropdown
+    id: package_status
+    attributes:
+      label: Package status
+      options:
+        - Public and current
+        - Deprecated compatibility package
+        - Experimental or private
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Mention related packages, renamed repositories, or anything maintainers should verify.
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: The package implements the QUBODrivers sampler interface.
+          required: true
+        - label: The source path is public and points to the optimizer implementation.
+          required: true
+        - label: The package should be listed as a current external sampler, or the deprecation reason is explained above.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+
+-
+
+## Validation
+
+-
+
+## Checklist
+
+- [ ] If this change adds or documents an external sampler package, update `docs/src/manual/3-samplers.md` with the package URL, solver type, and source file path.
+- [ ] If this change affects user-facing docs, run `julia --project=docs/ docs/make.jl --skip-deploy`.

--- a/docs/src/manual/3-samplers.md
+++ b/docs/src/manual/3-samplers.md
@@ -144,6 +144,11 @@ Several JuliaQUBO packages implement the same sampler interface for external
 libraries, heuristics, or services. Their source can be useful when building a
 new wrapper.
 
+This table is the reviewed source of truth for public external sampler
+packages. When a new JuliaQUBO or SECQUOIA driver package is ready for users,
+open a QUBODrivers documentation PR that adds its package URL, solver type, and
+source file path.
+
 | Project                                                                                   | Solver                                | Source Code                                                                                                                                |
 | :---------------------------------------------------------------------------------------- | :------------------------------------ | :----------------------------------------------------------------------------------------------------------------------------------------- |
 | [DWave.jl](https://github.com/JuliaQUBO/DWave.jl)                                         | `DWave.Optimizer`                     | [`src/sampler.jl`](https://github.com/JuliaQUBO/DWave.jl/blob/main/src/sampler.jl)                                                         |

--- a/docs/src/manual/7-integration.md
+++ b/docs/src/manual/7-integration.md
@@ -232,3 +232,25 @@ When the package is stable enough for wider use, register it with Julia's
 General registry using Registrator. Before registering, confirm the package has
 a unique UUID, an incremented `version`, explicit `[compat]` bounds, passing CI,
 and documentation that points users back to this QUBODrivers interface guide.
+
+### Registering the package with QUBODrivers docs
+
+If the sampler package is public and current in the JuliaQUBO or SECQUOIA
+organizations, open a QUBODrivers documentation PR that adds it to the external
+sampler table in `docs/src/manual/3-samplers.md`. That table is maintained as
+the reviewed source of truth rather than generated from GitHub search.
+
+Include:
+
+- the package repository URL;
+- the public solver type, such as `Package.Optimizer` or
+  `Package.Submodule.Optimizer`;
+- the source file path that defines the optimizer;
+- a note when the package is deprecated, renamed, experimental, private, or a
+  compatibility shim.
+
+For documentation-only registration PRs, run:
+
+```sh
+julia --project=docs/ docs/make.jl --skip-deploy
+```


### PR DESCRIPTION
## Summary

- Adds a lightweight issue template for registering public external sampler packages.
- Adds a compact PR checklist reminding contributors to update the external sampler table when relevant.
- Documents `docs/src/manual/3-samplers.md` as the reviewed source of truth and explains how JuliaQUBO/SECQUOIA driver authors should add package URL, solver type, source path, and status notes.

## Validation

- `julia --project=docs/ -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'`
- `julia --project=docs/ docs/make.jl --skip-deploy`
- `python -m unittest discover -s .github/tests -p 'test_*.py'`
- `git diff --cached --check`

Closes #57
