### PR TITLE
[codex] Add release process guardrails

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,74 @@
+# Release Process
+
+Release changes live in this repository first. The release preflight checks
+QUBODrivers metadata that can drift while preparing a package release.
+
+## Prepare the Release PR
+
+1. Update `Project.toml` to the target version.
+2. Move the top `CHANGELOG.md` section from `Unreleased` to `vX.Y.Z - YYYY-MM-DD`.
+3. Update `docs/Project.toml` self-compat for `QUBODrivers`.
+   - For `0.Y.Z`, use `0.Y`.
+   - For `0.0.Z`, use `0.0.Z`.
+   - For `X.Y.Z` with `X > 0`, use `X`.
+4. Run the static release preflight:
+
+```sh
+julia --project=. scripts/release_check.jl
+```
+
+5. Run the package and documentation checks:
+
+```sh
+julia --project=. -e 'import Pkg; Pkg.test()'
+julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'
+julia --project=docs docs/make.jl --skip-deploy
+```
+
+6. Open and merge the release PR after CI is green.
+
+## Register
+
+After the release PR is merged, invoke Registrator on the merge commit, not on
+the pull request. Use the template in `release-notes-template.md`.
+
+The release notes for a pre-1.0 minor release should include a
+`Breaking changes` or `Changelog` section. General may label pre-1.0 minor
+releases as `BREAKING`, and AutoMerge requires one of those words in the
+release notes when that label is present.
+
+```sh
+gh api repos/JuliaQUBO/QUBODrivers.jl/commits/<merge-sha>/comments -f body="$(cat release-notes-template.md)"
+```
+
+Watch the General registry PR:
+
+```sh
+gh pr checks <general-pr-number> --repo JuliaRegistries/General --watch
+gh pr view <general-pr-number> --repo JuliaRegistries/General --json state,mergedAt,mergeCommit,url
+```
+
+If AutoMerge fails because release notes are missing the breaking-change
+wording, re-invoke Registrator on the same merge commit with corrected release
+notes.
+
+## Verify TagBot
+
+After the General PR merges, wait for TagBot and verify the tag and release:
+
+```sh
+gh run list --workflow TagBot.yml --limit 10
+git ls-remote --tags origin vX.Y.Z
+gh release view vX.Y.Z
+```
+
+## Verify Pkg.add
+
+Use a fresh depot and project so the check does not reuse a local development
+path:
+
+```sh
+tmp="$(mktemp -d)"
+mkdir -p "$tmp/depot" "$tmp/proj"
+JULIA_DEPOT_PATH="$tmp/depot" julia --startup-file=no --project="$tmp/proj" -e 'using Pkg; Pkg.add("QUBODrivers"); deps = Pkg.dependencies(); versions = [(pkg.name, pkg.version) for pkg in values(deps) if pkg.name == "QUBODrivers"]; @show versions'
+```

--- a/release-notes-template.md
+++ b/release-notes-template.md
@@ -1,0 +1,19 @@
+@JuliaRegistrator register
+
+Release notes:
+
+## Breaking changes
+
+- No breaking changes, or list the behavioral/API change that makes this release breaking.
+
+## Added
+
+- TODO
+
+## Fixed
+
+- TODO
+
+## Maintenance
+
+- TODO

--- a/scripts/release_check.jl
+++ b/scripts/release_check.jl
@@ -1,0 +1,138 @@
+#!/usr/bin/env julia
+
+using TOML
+
+const ROOT = normpath(joinpath(@__DIR__, ".."))
+
+function release_line_compat(version::VersionNumber)
+    if version.major == 0
+        return version.minor == 0 ? "0.0.$(version.patch)" : "0.$(version.minor)"
+    end
+
+    return string(version.major)
+end
+
+function check!(failures::Vector{String}, condition::Bool, message::String)
+    condition || push!(failures, message)
+    return nothing
+end
+
+function project_file(parts...)
+    return joinpath(ROOT, parts...)
+end
+
+function read_toml(parts...)
+    return TOML.parsefile(project_file(parts...))
+end
+
+function release_heading_matches(line::AbstractString, version::VersionNumber)
+    prefix = "## v$(version)"
+    startswith(line, prefix) || return false
+    length(line) == length(prefix) && return true
+    return line[length(prefix) + 1] in (' ', '-', '(')
+end
+
+function release_section(changelog::String, version::VersionNumber)
+    lines = split(changelog, '\n')
+    start = findfirst(line -> release_heading_matches(line, version), lines)
+    start === nothing && return nothing
+
+    next_heading = findnext(line -> startswith(line, "## "), lines, start + 1)
+    stop = next_heading === nothing ? lastindex(lines) : next_heading - 1
+    return join(lines[start:stop], "\n")
+end
+
+function main()
+    failures = String[]
+    warnings = String[]
+
+    project = read_toml("Project.toml")
+    docs_project = read_toml("docs", "Project.toml")
+    test_project = read_toml("test", "Project.toml")
+
+    version = VersionNumber(project["version"])
+    expected_self_compat = release_line_compat(version)
+
+    check!(
+        failures,
+        project["name"] == "QUBODrivers",
+        "Project.toml name is not QUBODrivers.",
+    )
+
+    root_deps = project["deps"]
+    docs_deps = docs_project["deps"]
+    root_compat = project["compat"]
+    docs_compat = docs_project["compat"]
+    test_compat = test_project["compat"]
+
+    check!(
+        failures,
+        get(docs_deps, "QUBODrivers", nothing) == project["uuid"],
+        "docs/Project.toml must depend on this package UUID for QUBODrivers.",
+    )
+    check!(
+        failures,
+        get(docs_compat, "QUBODrivers", nothing) == expected_self_compat,
+        "docs/Project.toml compat for QUBODrivers must be \"$expected_self_compat\" for version $version.",
+    )
+    check!(
+        failures,
+        get(docs_compat, "MathOptInterface", nothing) == root_compat["MathOptInterface"],
+        "docs/Project.toml MathOptInterface compat must match Project.toml.",
+    )
+    check!(
+        failures,
+        get(docs_compat, "QUBOTools", nothing) == root_compat["QUBOTools"],
+        "docs/Project.toml QUBOTools compat must match Project.toml.",
+    )
+    check!(
+        failures,
+        get(test_compat, "PythonCall", nothing) == root_compat["PythonCall"],
+        "test/Project.toml PythonCall compat must match Project.toml.",
+    )
+    check!(
+        failures,
+        !haskey(root_deps, "ToQUBO") && !haskey(root_compat, "ToQUBO"),
+        "QUBODrivers should not depend on ToQUBO.",
+    )
+    check!(
+        failures,
+        haskey(root_compat, "julia"),
+        "Project.toml must declare Julia compat.",
+    )
+
+    changelog = read(project_file("CHANGELOG.md"), String)
+    section = release_section(changelog, version)
+    check!(
+        failures,
+        section !== nothing,
+        "CHANGELOG.md must contain a release heading for v$version.",
+    )
+
+    if section !== nothing &&
+       version.major == 0 &&
+       iszero(version.patch) &&
+       !occursin(r"(?i)\b(breaking|changelog)\b", section)
+        push!(
+            warnings,
+            "CHANGELOG.md section for v$version does not mention `breaking` or `changelog`; General AutoMerge may require one of those words if the registry labels the release BREAKING.",
+        )
+    end
+
+    if isempty(failures)
+        println("Release preflight passed for QUBODrivers v$version.")
+        println("Expected docs self-compat: QUBODrivers = \"$expected_self_compat\".")
+    else
+        println(stderr, "Release preflight failed:")
+        foreach(message -> println(stderr, "- ", message), failures)
+    end
+
+    if !isempty(warnings)
+        println(stderr, "\nWarnings:")
+        foreach(message -> println(stderr, "- ", message), warnings)
+    end
+
+    return isempty(failures) ? 0 : 1
+end
+
+exit(main())


### PR DESCRIPTION
## Summary

Adds QUBODrivers release guardrails as part of JuliaQUBO/QUBO.jl#44:

- add `scripts/release_check.jl` to validate release-sensitive metadata before Registrator;
- add `RELEASE.md` with the release PR, registration, TagBot, and fresh `Pkg.add` verification flow;
- add `release-notes-template.md` with explicit `Breaking changes` wording for pre-1.0 minor releases that General labels as breaking.

The preflight mirrors the existing project-compat assertions from the test suite so release prep can fail fast without running the full package tests first.

## Validation

- `julia +release --project=. scripts/release_check.jl`
- `julia +release --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'`
- `julia +release --project=docs docs/make.jl --skip-deploy`
- `julia +release --project=. -e 'import Pkg; Pkg.test()'`
- `git diff --cached --check`

The package test passed `992/992`. The docs build passed with the expected local deployment-skip warning.
