### PR TITLE
Release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## v0.6.2 - 2026-06-22
+
+### Added / Changed / Maintenance
+
+- Document public external sampler packages with solver types and source paths,
+  and add the registration workflow for future sampler documentation updates.
+- Add issue and pull request templates for external sampler documentation
+  changes.
+- Harden TagBot permissions for issue-comment release automation.
+- Add release process guardrails and a static release preflight check.
+
 ## v0.6.1 - 2026-06-11
 
 ### Added / Changed / Maintenance

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBODrivers"
 uuid = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "AndradeTiago <tiago.andrade@psr-inc.com>", "joaquimg <joaquim@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"


### PR DESCRIPTION
## Summary

- Bump QUBODrivers to v0.6.2.
- Add the v0.6.2 changelog entry for external sampler docs, TagBot permissions, and release guardrails.

## Validation

- `julia --project=. scripts/release_check.jl`
- `julia --project=. -e 'import Pkg; Pkg.test()'`
- `julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'`
- `julia --project=docs docs/make.jl --skip-deploy`
