### PR TITLE
Release v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## v0.6.5 - 2026-06-25
+
+### Added / Changed / Maintenance
+
+- Allow QUBOTools 0.16 while retaining QUBOTools 0.10, 0.11, 0.12, 0.13,
+  0.14, and 0.15 compatibility.
+
 ## v0.6.4 - 2026-06-24
 
 ### Added / Changed / Maintenance

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QUBODrivers"
 uuid = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "pedroripper <pedroripper@psr-inc.com>", "AndradeTiago <tiago.andrade@psr-inc.com>", "joaquimg <joaquim@psr-inc.com>", "bernalde <dbernaln@purdue.edu>"]
-version = "0.6.4"
+version = "0.6.5"
 
 [deps]
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"


### PR DESCRIPTION
Summary

- Bump QUBODrivers to `v0.6.5`.
- Add the `v0.6.5 - 2026-06-25` changelog entry.
- Keep docs self-compat at `QUBODrivers = "0.6"`, which is correct for the `0.6.x` release line.

Release contents

- This patch release publishes the QUBOTools 0.16 compatibility added in #64.
- No API or behavior changes are included beyond releasing the widened compat bound.

Validation

- `julia --project=. scripts/release_check.jl`: passed.
- `julia +release --project=. -e 'import Pkg; Pkg.test(; coverage=false)'`: passed, 992 tests.
- `julia +release --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'`: passed.
- `julia +release --project=docs docs/make.jl --skip-deploy`: passed.
- `python -m unittest discover -s .github/tests -p "test_*.py"`: passed, 14 tests.

Release follow-up

- After merge, invoke Registrator on the merge commit for `v0.6.5`.
- After General merges and TagBot runs, verify a fresh `Pkg.add("QUBODrivers")` resolves `QUBODrivers v0.6.5`.
