### PR TITLE
Make workflow action tests tolerate major bumps

### DIFF
--- a/.github/tests/test_label_automation.py
+++ b/.github/tests/test_label_automation.py
@@ -1,9 +1,13 @@
 import pathlib
+import re
 import unittest
 
 import yaml
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
+ACTION_VERSION_REF = re.compile(r"v(?P<major>[1-9]\d*)(?:\.\d+){0,2}")
+MINIMUM_LABELER_MAJOR = 6
+MINIMUM_SHARED_CHECKOUT_MAJOR = 6
 
 # Minimum set of glob patterns the documentation label must cover.
 # This is a contract floor — removing a pattern here is a deliberate
@@ -24,12 +28,86 @@ REQUIRED_DOC_PATTERNS = (
 )
 
 
+def parse_action_major(uses: object) -> tuple[str, int]:
+    if not isinstance(uses, str):
+        raise ValueError(f"Action reference must be a string, got {uses!r}")
+
+    action, separator, ref = uses.rpartition("@")
+    if not separator or not action:
+        raise ValueError(f"Action reference {uses!r} must be pinned as owner/name@vN")
+
+    match = ACTION_VERSION_REF.fullmatch(ref)
+    if match is None:
+        raise ValueError(f"Action reference {uses!r} must use a pinned vN version ref")
+
+    return action, int(match.group("major"))
+
+
 class LabelAutomationContractTests(unittest.TestCase):
     def read_text(self, relative_path: str) -> str:
         return (ROOT / relative_path).read_text(encoding="utf-8")
 
     def load_yaml(self, relative_path: str):
         return yaml.safe_load(self.read_text(relative_path))
+
+    def assert_uses_action_at_least(
+        self,
+        uses: object,
+        expected_action: str,
+        minimum_major: int,
+    ) -> None:
+        try:
+            action, major = parse_action_major(uses)
+        except ValueError as exc:
+            self.fail(str(exc))
+
+        self.assertEqual(action, expected_action)
+        self.assertGreaterEqual(
+            major,
+            minimum_major,
+            f"{expected_action} must use v{minimum_major} or newer",
+        )
+
+    def test_action_reference_parser_accepts_supported_major_bumps(self) -> None:
+        self.assertEqual(
+            parse_action_major("actions/labeler@v7"),
+            ("actions/labeler", 7),
+        )
+        self.assertEqual(
+            parse_action_major("actions/checkout@v7"),
+            ("actions/checkout", 7),
+        )
+        self.assertEqual(
+            parse_action_major("actions/checkout@v6.0.2"),
+            ("actions/checkout", 6),
+        )
+
+    def test_action_reference_parser_rejects_stale_and_floating_refs(self) -> None:
+        with self.assertRaises(AssertionError):
+            self.assert_uses_action_at_least(
+                "actions/labeler@v5",
+                "actions/labeler",
+                MINIMUM_LABELER_MAJOR,
+            )
+        with self.assertRaises(AssertionError):
+            self.assert_uses_action_at_least(
+                "actions/checkout@v5",
+                "actions/checkout",
+                MINIMUM_SHARED_CHECKOUT_MAJOR,
+            )
+
+        with self.assertRaises(AssertionError):
+            self.assert_uses_action_at_least(
+                "actions/labeler@latest",
+                "actions/labeler",
+                MINIMUM_LABELER_MAJOR,
+            )
+        with self.assertRaises(AssertionError):
+            self.assert_uses_action_at_least(
+                "actions/checkout@latest",
+                "actions/checkout",
+                MINIMUM_SHARED_CHECKOUT_MAJOR,
+            )
 
     def test_documentation_labeler_uses_any_glob_to_all_files(self) -> None:
         labeler = self.load_yaml(".github/labeler.yml")
@@ -83,13 +161,23 @@ class LabelAutomationContractTests(unittest.TestCase):
             header,
         )
 
-    def test_pr_labeler_uses_node24_labeler_action(self) -> None:
+    def test_pr_labeler_uses_supported_labeler_action(self) -> None:
         workflow = self.load_yaml(".github/workflows/pr-labeler.yml")
         steps = workflow["jobs"]["label"]["steps"]
+        labeler_steps = [
+            step
+            for step in steps
+            if step.get("uses", "").startswith("actions/labeler@")
+        ]
 
-        self.assertIn("actions/labeler@v6", [step.get("uses") for step in steps])
+        self.assertEqual(len(labeler_steps), 1)
+        self.assert_uses_action_at_least(
+            labeler_steps[0].get("uses"),
+            "actions/labeler",
+            MINIMUM_LABELER_MAJOR,
+        )
 
-    def test_shared_label_maintenance_uses_node24_checkout(self) -> None:
+    def test_shared_label_maintenance_uses_supported_checkout(self) -> None:
         for workflow_path, job_name in (
             (".github/workflows/label-sync.yml", "sync"),
             (".github/workflows/label-backfill.yml", "backfill"),
@@ -99,14 +187,18 @@ class LabelAutomationContractTests(unittest.TestCase):
             checkout_steps = [
                 step
                 for step in steps
-                if step.get("uses") == "actions/checkout@v6"
-                and step.get("with", {}).get("repository") == "JuliaQUBO/.github"
+                if step.get("with", {}).get("repository") == "JuliaQUBO/.github"
             ]
 
             self.assertEqual(
                 len(checkout_steps),
                 1,
-                f"{workflow_path} should check out shared label automation with checkout@v6",
+                f"{workflow_path} should check out shared label automation once",
+            )
+            self.assert_uses_action_at_least(
+                checkout_steps[0].get("uses"),
+                "actions/checkout",
+                MINIMUM_SHARED_CHECKOUT_MAJOR,
             )
 
 


### PR DESCRIPTION
## Summary

- Parse GitHub Action `uses:` references into action name and pinned version major.
- Allow supported major bumps for shared label checkout and PR labeler actions.
- Keep rejecting stale majors below v6 and floating refs such as `@latest`.

Closes #66

## Tests

- `bash .github/tests/doc_preview_cleanup.sh`
- `python -m unittest discover -s .github/tests -p "test_*.py"`

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `29d61d7`
- Stacked status: not stacked
- Prerequisite PRs: none
