### PR TITLE
Align CI baseline for Wave 1

### DIFF
--- a/.github/tests/test_julia_ci_policy.py
+++ b/.github/tests/test_julia_ci_policy.py
@@ -9,7 +9,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 MINIMUM_JULIA_VERSION = "1.10"
 LATEST_STABLE_JULIA_VERSION = "1"
 QUBOTOOLS_CURRENT_COMPAT_VERSION = "0.16"
-SUPPORTED_CI_RUNNERS = {"ubuntu-latest", "windows-2025-vs2026"}
+SUPPORTED_CI_RUNNERS = {"ubuntu-latest", "windows-latest"}
 DEPRECATED_WORKFLOW_REFERENCES = (
     "actions/checkout@v4",
     "actions/setup-python@v5",
@@ -17,7 +17,7 @@ DEPRECATED_WORKFLOW_REFERENCES = (
     "julia-actions/setup-julia@latest",
     "actions/labeler@v5",
     "codecov/codecov-action@v5",
-    "windows-latest",
+    "windows-2025-vs2026",
 )
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-          - windows-2025-vs2026
+          - windows-latest
         arch:
           - x64
     steps:


### PR DESCRIPTION
## Summary

- Align the package CI Windows matrix with the Wave 1 baseline by using `windows-latest`.
- Update the workflow regression test so the baseline runners are `ubuntu-latest` and `windows-latest`.
- Leave the existing aligned pieces in place: `CI` workflow name, Julia `1.10` and `1` matrix entries, `julia-actions/cache`, weekly Julia Dependabot, and monthly GitHub Actions Dependabot.

Closes #68.

## Tests run

- `git diff --check`
- `bash .github/tests/doc_preview_cleanup.sh`
- `python -m unittest discover -s .github/tests -p "test_*.py"`
- `actionlint`

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` after `git fetch origin --prune`
- Stacked status: not stacked
- Prerequisite PRs: none
